### PR TITLE
Fixed Satin Panties album in metadata

### DIFF
--- a/assets/data/satin-panties/meta.json
+++ b/assets/data/satin-panties/meta.json
@@ -1,6 +1,6 @@
 {
   "name": "Satin Panties",
   "artist": "Kawai Sprite",
-  "album": "ext1",
+  "album": "vol1",
   "difficulties": [2, 2, 3]
 }


### PR DESCRIPTION
Satin Panties has `ext1` album in metadata instead of `vol1`.