### PR TITLE
Make `sad` animation function properly

### DIFF
--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -2654,7 +2654,7 @@ class PlayState extends MusicBeatState
 
 	function comboBreak():Void{
 		if (combo > minCombo){
-			gf.playAnim('sad');
+			gf.playAnim('sad', true);
 			comboUI.breakPopup();
 		}
 		if(combo > 0){ songStats.comboBreakCount++; }

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -1324,9 +1324,7 @@ class PlayState extends MusicBeatState
 
 		if (comboBroken == true) {
 			comboBreakAnimation();
-			if (!(gf.curAnim != 'sad') && gf.curAnimFinished()) {
-					comboBroken = false;
-			}
+			comboBroken = false;
 		}
 
 		stage.update(elapsed);

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -179,6 +179,7 @@ class PlayState extends MusicBeatState
 
 	public var combo:Int = 0;
 	public var totalPlayed:Int = 0;
+	public var comboBroken:Bool = false;
 
 	public var healthBarBG:FlxSprite;
 	public var healthBar:FlxBar;
@@ -1322,6 +1323,10 @@ class PlayState extends MusicBeatState
 		super.update(elapsed);
 
 		stage.update(elapsed);
+		if (comboBroken == true) {
+			gf.playAnim('sad', true);
+		}
+		
 
 		if(!startingSong){
 			for(i in eventList){
@@ -2654,7 +2659,8 @@ class PlayState extends MusicBeatState
 
 	function comboBreak():Void{
 		if (combo > minCombo){
-			gf.playAnim('sad', true);
+			//gf.playAnim('sad', true);
+			comboBroken = true;
 			comboUI.breakPopup();
 		}
 		if(combo > 0){ songStats.comboBreakCount++; }

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -1322,11 +1322,14 @@ class PlayState extends MusicBeatState
 
 		super.update(elapsed);
 
-		stage.update(elapsed);
 		if (comboBroken == true) {
-			gf.playAnim('sad', true);
+			comboBreakAnimation();
+			if (!(gf.curAnim != 'sad') && gf.curAnimFinished()) {
+					comboBroken = false;
+			}
 		}
-		
+
+		stage.update(elapsed);
 
 		if(!startingSong){
 			for(i in eventList){
@@ -2659,12 +2662,17 @@ class PlayState extends MusicBeatState
 
 	function comboBreak():Void{
 		if (combo > minCombo){
-			//gf.playAnim('sad', true);
 			comboBroken = true;
 			comboUI.breakPopup();
 		}
 		if(combo > 0){ songStats.comboBreakCount++; }
 		combo = 0;
+	}
+
+	function comboBreakAnimation():Void{
+		
+		gf.playAnim('sad');
+		
 	}
 
 	static function inRange(a:Float, b:Float, tolerance:Float):Bool{

--- a/source/characters/data/Gf.hx
+++ b/source/characters/data/Gf.hx
@@ -63,7 +63,7 @@ class Gf extends CharacterInfoBase
 	}
 
 	function danceOverride(character:Character):Void{
-		if (!character.curAnim.startsWith('hair') || !character.curAnim.startsWith('sad')){
+		if (!character.curAnim.startsWith('hair') || !(character.curAnim == "sad")){
 			character.defaultDanceBehavior();
 		}
 	}

--- a/source/characters/data/Gf.hx
+++ b/source/characters/data/Gf.hx
@@ -56,14 +56,14 @@ class Gf extends CharacterInfoBase
 		}
 	}
 
-	function update(character:Character, elpased:Float):Void{
+	function update(character:Character, elapsed:Float):Void{
 		if (character.curAnim == 'hairFall' && character.curAnimFinished()){
 			character.playAnim('danceRight');
 		}
 	}
 
 	function danceOverride(character:Character):Void{
-		if (!character.curAnim.startsWith('hair') || !(character.curAnim == "sad")){
+		if (!character.curAnim.startsWith('hair') || character.curAnim != 'sad'){
 			character.defaultDanceBehavior();
 		}
 	}

--- a/source/characters/data/Gf.hx
+++ b/source/characters/data/Gf.hx
@@ -63,7 +63,7 @@ class Gf extends CharacterInfoBase
 	}
 
 	function danceOverride(character:Character):Void{
-		if (!character.curAnim.startsWith('hair')){
+		if (!character.curAnim.startsWith('hair') || !character.curAnim.startsWith('sad')){
 			character.defaultDanceBehavior();
 		}
 	}

--- a/source/characters/data/Nene.hx
+++ b/source/characters/data/Nene.hx
@@ -80,7 +80,7 @@ class Nene extends CharacterInfoBase
     }
 
     function danceOverride(character:Character):Void{
-        if(!knifeRaised || !character.curAnim.startsWith('sad')){
+        if(!knifeRaised || !(character.curAnim == "sad")){
             character.defaultDanceBehavior();
         }
     }

--- a/source/characters/data/Nene.hx
+++ b/source/characters/data/Nene.hx
@@ -2,6 +2,7 @@ package characters.data;
 
 import flixel.FlxG;
 import flixel.math.FlxPoint;
+using StringTools
 
 @charList(false)
 @gfList(true)
@@ -22,7 +23,7 @@ class Nene extends CharacterInfoBase
 		addByIndices("danceLeft", offset(0, 0), "Idle", [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14], "", 24, loop(false, 0), false, false);
         addByIndices("danceRight", offset(0, 0), "Idle", [15,16,17,18,19,20,21,22,23,24,25,26,27,28,29], "", 24, loop(false, 0), false, false);
         addByPrefix("idleLoop", offset(0, 0), "Idle", 24, loop(true, 0), false, false);
-        addByIndices("sad", offset(0, 0), "Laugh", [0,1,2,3,4,5,6], "", 24, loop(false, 0), false, false);
+        addByIndices("sad", offset(0, 0), "Laugh", [0,1,2,3,4,5,6,7,8,9,10,11,7,8,9,10,11,7,8,9,10,11], "", 24, loop(false, 0), false, false);
         addByIndices("laughCutscene", offset(0, 0), "Laugh", [0,1,2,3,4,5,6,7,8,9,10,11,7,8,9,10,11,7,8,9,10,11,7,8,9,10,11,7,8,9,10,11,7,8,9,10,11], "", 24, loop(false, 0), false, false);
         addByPrefix("comboCheer", offset(-120, 53), "ComboCheer", 24, loop(false, 0), false, false);
         addByIndices("comboCheerHigh", offset(-40, -20), "ComboFawn", [0,1,2,3,4,5,6,4,5,6,4,5,6,4,5,6], "", 24, loop(false, 0), false, false);
@@ -79,7 +80,7 @@ class Nene extends CharacterInfoBase
     }
 
     function danceOverride(character:Character):Void{
-        if(!knifeRaised){
+        if(!knifeRaised || !character.curAnim.startsWith('sad')){
             character.defaultDanceBehavior();
         }
     }

--- a/source/characters/data/Nene.hx
+++ b/source/characters/data/Nene.hx
@@ -80,7 +80,7 @@ class Nene extends CharacterInfoBase
     }
 
     function danceOverride(character:Character):Void{
-        if(!knifeRaised || !(character.curAnim == "sad")){
+        if(!knifeRaised || character.curAnim != 'sad'){
             character.defaultDanceBehavior();
         }
     }

--- a/source/characters/data/Nene.hx
+++ b/source/characters/data/Nene.hx
@@ -2,7 +2,7 @@ package characters.data;
 
 import flixel.FlxG;
 import flixel.math.FlxPoint;
-using StringTools
+using StringTools;
 
 @charList(false)
 @gfList(true)


### PR DESCRIPTION
The commit name describes the changes I made. I meant "enforce sad" rather than "avoid sad". Next step is to add some way to globally enforce these animations (at least `sad`) across all speakergirls/gfs.
I also made Nene's `sad` animation have the giggle loop 3 times, as opposed to `laughCutscene`'s 6.