### PR TITLE
Polymod-independent Scripting System

### DIFF
--- a/Project.xml
+++ b/Project.xml
@@ -164,5 +164,5 @@
 	<haxedef name="POLYMOD_SCRIPT_LIBRARY" value="data" />
 	<haxedef name="POLYMOD_APPEND_FOLDER" value="append" />
 	<haxedef name="POLYMOD_MERGE_FOLDER" value="merge" />
-
+	<haxedef name="hscriptPos" /> <!-- for logging -->
 </project>

--- a/source/GameOverSubstate.hx
+++ b/source/GameOverSubstate.hx
@@ -71,7 +71,7 @@ class GameOverSubstate extends MusicBeatSubstate
 		}
 		
 		PlayState.instance.stage.gameOverStart();
-		for(script in PlayState.instance.loadedScripts){ script.gameOverStart(); }
+		for(script in PlayState.instance.loadedScripts){ script.callFunc("gameOverStart"); }
 	}
 
 	override function update(elapsed:Float){
@@ -99,7 +99,7 @@ class GameOverSubstate extends MusicBeatSubstate
 			}
 
 			PlayState.instance.stage.gameOverLoop();
-			for(script in PlayState.instance.loadedScripts){ script.gameOverLoop(); }
+			for(script in PlayState.instance.loadedScripts){ script.callFunc("gameOverLoop"); }
 		}
 
 		if (FlxG.sound.music.playing){
@@ -126,7 +126,7 @@ class GameOverSubstate extends MusicBeatSubstate
 			FlxG.sound.play(Paths.music(bf.deathSongEnd));
 		}
 		PlayState.instance.stage.gameOverEnd();
-		for(script in PlayState.instance.loadedScripts){ script.gameOverEnd(); }
+		for(script in PlayState.instance.loadedScripts){ script.callFunc("gameOverEnd"); }
 		new FlxTimer().start(0.4, function(tmr:FlxTimer){
 			camGameOver.fade(FlxColor.BLACK, 1.2, false, function(){
 				PlayState.instance.switchState(new PlayState());

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -1,6 +1,5 @@
 package;
 
-import scripts.ScriptableScript;
 import scripts.Script;
 import modding.PolymodHandler;
 import openfl.filters.ShaderFilter;
@@ -662,15 +661,21 @@ class PlayState extends MusicBeatState
 			//trace(endCutsceneStoryOnly);
 		}
 
-		if(Utils.exists(Paths.json("scripts", "data/songs/" + SONG.song.toLowerCase()))){
-			trace("song has scripts");
-			var scriptJson = Json.parse(Utils.getText(Paths.json("scripts", "data/songs/" + SONG.song.toLowerCase())));
-			var scriptList:Array<String> = scriptJson.scripts;
-			for(script in scriptList){
-				if(ScriptableScript.listScriptClasses().contains(script)){
-					var scriptToAdd:Script = ScriptableScript.init(script);
-					loadedScripts.push(scriptToAdd);
-				}
+		//"Global" Scripts
+		for(script in Utils.readDirectory("assets/data/global")){
+			if(script.endsWith(".hxc")){
+				var scriptToAdd:Script = new Script("assets/data/global/" + script);
+				scriptToAdd.parent = PlayState.instance;
+				loadedScripts.push(scriptToAdd);
+			}
+		}
+
+		//Song Scripts
+		for(script in Utils.readDirectory("assets/data/"+SONG.song.toLowerCase())){
+			if(script.endsWith(".hxc")){
+				var scriptToAdd:Script = new Script("assets/data/" + SONG.song.toLowerCase() + "/" + script);
+				scriptToAdd.parent = PlayState.instance;
+				loadedScripts.push(scriptToAdd);
 			}
 		}
 
@@ -688,7 +693,7 @@ class PlayState extends MusicBeatState
 		fceForLilBuddies = false;
 		
 		stage.postCreate();
-		for(script in loadedScripts){ script.create(); }
+		for(script in loadedScripts){ script.callFunc("create"); }
 		
 		cutsceneCheck();
 
@@ -743,7 +748,7 @@ class PlayState extends MusicBeatState
 		var countdownSkin:CountdownSkinBase = new CountdownSkinBase(countdownSkinName);
 
 		stage.countdownBeat(-1);
-		for(script in loadedScripts){ script.countdownBeat(-1); }
+		for(script in loadedScripts){ script.callFunc("countdownBeat", [-1]); }
 
 		startTimer = new FlxTimer().start(Conductor.crochet / 1000, function(tmr:FlxTimer)
 		{
@@ -858,7 +863,7 @@ class PlayState extends MusicBeatState
 
 			if(swagCounter < 4){
 				stage.countdownBeat(swagCounter);
-				for(script in loadedScripts){ script.countdownBeat(swagCounter); }
+				for(script in loadedScripts){ script.callFunc("countdownBeat", [swagCounter]); }
 			}
 
 			swagCounter++;
@@ -917,13 +922,13 @@ class PlayState extends MusicBeatState
 			gf.characterInfo.info.functions.songStart(gf);
 		}
 		stage.songStart();
-		for(script in loadedScripts){ script.songStart(); }
+		for(script in loadedScripts){ script.callFunc("songStart"); }
 
 		boyfriend.step(0);
 		dad.step(0);
 		gf.step(0);
 		stage.step(0);
-		for(script in loadedScripts){ script.step(0); }
+		for(script in loadedScripts){ script.callFunc("stepHit", [0]); }
 
 		beatHit();
 	}
@@ -1266,7 +1271,7 @@ class PlayState extends MusicBeatState
 
 			if(goingToPause){
 				stage.pause();
-				for(script in loadedScripts){ script.pause(); }
+				for(script in loadedScripts){ script.callFunc("pause"); }
 			}
 		}
 
@@ -1289,7 +1294,7 @@ class PlayState extends MusicBeatState
 
 			if(goingToPause){
 				stage.unpause();
-				for(script in loadedScripts){ script.unpause(); }
+				for(script in loadedScripts){ script.callFunc("unpause"); }
 				goingToPause = false;
 			}
 		}
@@ -1377,7 +1382,7 @@ class PlayState extends MusicBeatState
 		super.update(elapsed);
 
 		stage.update(elapsed);
-		for(script in loadedScripts){ script.update(elapsed); }
+		for(script in loadedScripts){ script.callFunc("update", [elapsed]); }
 
 		if(!startingSong){
 			for(i in eventList){
@@ -1657,6 +1662,7 @@ class PlayState extends MusicBeatState
 					daNote.destroy();
 				}
 			}
+			for(script in loadedScripts){ script.callFunc("updateNote", [daNote]); }
 		});
 	}
 
@@ -2344,7 +2350,7 @@ class PlayState extends MusicBeatState
 		dad.step(curStep+1);
 		gf.step(curStep+1);
 		stage.step(curStep+1);
-		for(script in loadedScripts){ script.step(curStep+1); }
+		for(script in loadedScripts){ script.callFunc("stepHit",[curStep+1]); }
 
 		super.stepHit();
 	}
@@ -2397,7 +2403,7 @@ class PlayState extends MusicBeatState
 		dad.beat(curBeat);
 		gf.beat(curBeat);
 		stage.beat(curBeat);
-		for(script in loadedScripts){ script.beat(curBeat); }
+		for(script in loadedScripts){ script.callFunc("beatHit", [curBeat]); }
 		
 	}
 
@@ -2811,7 +2817,7 @@ class PlayState extends MusicBeatState
 
 	function preStateChange():Void{
 		stage.exit();
-		for(script in loadedScripts){ script.exit(); }
+		for(script in loadedScripts){ script.callFunc("exit"); }
 	}
 
 }

--- a/source/Utils.hx
+++ b/source/Utils.hx
@@ -135,7 +135,10 @@ class Utils
 
 	//FileSystem readDirectory but with mods folder
 	public static inline function readDirectory(path:String):Array<String>{
-		var files:Array<String> = FileSystem.readDirectory(path);
+		var files:Array<String> = [];
+		if (FileSystem.exists(path)){
+			files = FileSystem.readDirectory(path);
+		}
 		for (mod in PolymodHandler.loadedModDirs){
 			if (FileSystem.exists('mods/$mod/' + path.split("assets/")[1])){
 				if(files == null){ files = []; }

--- a/source/modding/ModManagerState.hx
+++ b/source/modding/ModManagerState.hx
@@ -8,7 +8,6 @@ import haxe.Json;
 import sys.FileSystem;
 import openfl.display.BitmapData;
 import flixel.FlxG;
-import flixel.FlxG;
 import flixel.tweens.FlxEase;
 import flixel.tweens.FlxTween;
 import flixel.util.FlxColor;

--- a/source/modding/PolymodHandler.hx
+++ b/source/modding/PolymodHandler.hx
@@ -26,6 +26,13 @@ class PolymodHandler
 	public static function init():Void{
         buildImports();
 
+        Polymod.init({
+			modRoot: "mods",
+			useScriptedClasses: true,
+            errorCallback: onPolymodError,
+            frameworkParams: buildFrameworkParams()
+		});
+        
         reInit();
 
         scriptableClassCheck();
@@ -38,21 +45,16 @@ class PolymodHandler
     }
 
     public static function reInit():Void{
-        buildModDirectories();
-
-        loadedModMetadata = Polymod.init({
-			modRoot: "./mods/",
-			dirs: loadedModDirs,
-			useScriptedClasses: true,
-            errorCallback: onPolymodError,
-            frameworkParams: buildFrameworkParams()
-		});
-
-        trace("Mod Meta List: " + loadedModMetadata);
-
+        Polymod.unloadAllMods();
         Polymod.clearCache();
 
+        buildModDirectories();
+        //Shold prevents exceptional errors....maybe
+        Polymod.loadMods(loadedModDirs);
+
         reloadScripts();
+
+        trace("Loaded Mods: " + Polymod.getLoadedModIds());
     }
 
     public static function buildModDirectories():Void{

--- a/source/modding/PolymodHandler.hx
+++ b/source/modding/PolymodHandler.hx
@@ -200,7 +200,6 @@ class PolymodHandler
         trace("ScriptableNoteSkin: " + note.ScriptableNoteSkin.listScriptClasses());
         trace("ScriptableCutscene: " + cutscenes.ScriptableCutscene.listScriptClasses());
         trace("ScriptableStage: " + stages.ScriptableStage.listScriptClasses());
-        trace("ScriptableScript: " + scripts.ScriptableScript.listScriptClasses());
         trace("ScriptableCharacterSelectCharacter: " + characterSelect.ScriptableCharacterSelectCharacter.listScriptClasses());
         trace("ScriptableDJCharacter: " + freeplay.ScriptableDJCharacter.listScriptClasses());
         trace("ScriptableResultsCharacter: " + results.ScriptableResultsCharacter.listScriptClasses());

--- a/source/scripts/Script.hx
+++ b/source/scripts/Script.hx
@@ -1,94 +1,93 @@
 package scripts;
 
-import flixel.FlxG;
-import flixel.FlxBasic;
+import hscript.Parser;
+import hscript.Interp;
 
-@:build(modding.GlobalScriptingTypesMacro.build())
-class Script
+using StringTools;
+
+class Script extends Interp
 {
-    /**
-	* Called when the script is created.
-	*/
-    public function create(){}
+    public var parent:Dynamic;
+    private var parser:Parser;
 
-    /**
-     * Called every frame in PlayState update.
-     *
-     * @param   elpased  The elapsed time between previous frames passed in by PlayState.
-     */
-    public function update(elapsed:Float){}
- 
-    /**
-     * Called every beat hit in PlayState.
-     *
-     * @param   curBeat  The current song beat passed in by PlayState.
-     */
-    public function beat(curBeat:Int){}
- 
-    /**
-     * Called every beat during the countdown.
-     *
-     * @param   curBeat  The current song beat passed in by PlayState.
-     */
-    public function countdownBeat(curBeat:Int){}
- 
-    /**
-     * Called every step hit in PlayState.
-     *
-     * @param   curStep  The current song step passed in by PlayState.
-     */
-    public function step(curStep:Int){}
- 
-    /**
-     * Called once the song starts.
-     */
-    public function songStart(){}
- 
-    /**
-     * Called when the game is paused.
-     */
-    public function pause(){}
- 
-    /**
-     * Called when the game is unpaused.
-     */
-    public function unpause(){}
- 
-    /**
-     * Called when the game over state is started.
-     */
-    public function gameOverStart(){}
- 
-    /**
-     * Called when the starting the game over loop animation.
-     */
-    public function gameOverLoop(){}
- 
-    /**
-     * Called when the game over retry is confirmed.
-     */
-    public function gameOverEnd(){}
- 
-    /**
-     * Called when the leaving PlayState.
-     */
-    public function exit(){}
+    override public function new(path:String){
+        super();
+        setVariables();
 
-    inline function addToBackground(x:FlxBasic)         { PlayState.instance.backgroundLayer.add(x); }
-    inline function removeFromBackground(x:FlxBasic)    { PlayState.instance.backgroundLayer.remove(x); }
-    inline function addToGf(x:FlxBasic)                 { PlayState.instance.gfLayer.add(x); }
-    inline function removeFromGf(x:FlxBasic)            { PlayState.instance.gfLayer.remove(x); }
-    inline function addToMiddle(x:FlxBasic)             { PlayState.instance.middleLayer.add(x); }
-    inline function removeFromMiddle(x:FlxBasic)        { PlayState.instance.middleLayer.remove(x); }
-    inline function addToCharacter(x:FlxBasic)          { PlayState.instance.characterLayer.add(x); }
-    inline function removeFromCharacter(x:FlxBasic)     { PlayState.instance.characterLayer.remove(x); }
-    inline function addToForeground(x:FlxBasic)         { PlayState.instance.foregroundLayer.add(x); }
-    inline function removeFromForeground(x:FlxBasic)    { PlayState.instance.foregroundLayer.remove(x); }
+        parser = new Parser();
+        parser.allowJSON = parser.allowMetadata = parser.allowTypes = true;
+        
+        var scriptStrings = Utils.getTextInLines(path);
+        
+        var scriptToRun:String = "";
+        for (line in scriptStrings){
+            switch(line.split(" ")[0]){
+                case "import":
+                    importClass(line.split("import ")[1].split(";")[0]);
+                    line = "//import " + line.split("import ")[1];
+            }
+            
+            scriptToRun += line + "\n";
+        }
 
-    inline function addGeneric(x:FlxBasic)              { FlxG.state.add(x); }
-    inline function removeGeneric(x:FlxBasic)           { FlxG.state.remove(x); }
-    inline function addGenericSubstate(x:FlxBasic)      { FlxG.state.subState.add(x); }
-    inline function removeGenericSubstate(x:FlxBasic)   { FlxG.state.subState.remove(x); }
+        var parsedScript = parser.parseString(scriptToRun);
+        execute(parsedScript);
+    }
 
-    public function toString():String{ return "Script"; }
+    //call Function in Interp
+    public function callFunc(func:String, ?args:Array<Dynamic>):Dynamic {
+		if (variables.exists(func)) {
+			if (args == null) args = [];
+			try {
+				return Reflect.callMethod(null, variables.get(func), args);
+			}
+			catch(e){
+				trace(e.message);
+            }
+		}
+		return null;
+	}
+
+    //import Class to Interp from String
+    public function importClass(classPath:String) {
+        var className:String = classPath.split(".")[classPath.split(".").length - 1];
+
+        if (variables.exists(className)){
+            trace(className + "already imported!");
+            return;
+        }
+
+        variables.set(className, Type.resolveClass(classPath));
+	}
+
+    private function setVariables(){
+        importClass("Paths");
+        importClass("Character");
+        importClass("Utils");
+        importClass("Conductor");
+        importClass("PlayState");
+        importClass("Math");
+        importClass("StringTools");
+
+        variables.set('add', flixel.FlxG.state.add);
+		variables.set('insert', flixel.FlxG.state.insert);
+		variables.set('remove', flixel.FlxG.state.remove);
+    }
+
+    //get Parents var too
+    override public function resolve(id:String):Dynamic {
+		if (parent != null) {
+            var instanceFields = Type.getInstanceFields(Type.getClass(parent));
+			// search in object
+			if (id == "this"){ return parent; }
+            if ((Type.typeof(parent) == TObject) && Reflect.hasField(parent, id)) {
+				return Reflect.field(parent, id);
+			}
+			if (instanceFields.contains(id)) {
+				return Reflect.getProperty(parent, id);
+            }
+		}
+
+		return super.resolve(id);
+	}
 }

--- a/source/scripts/Script.hx
+++ b/source/scripts/Script.hx
@@ -5,39 +5,42 @@ import hscript.Interp;
 
 using StringTools;
 
+/**
+	Enhanced Hscript Interpreter that supports importing Package, get Object from parent instance...
+	@author Soushimiya
+**/
+
 class Script extends Interp
 {
     public var parent:Dynamic;
-    private var parser:Parser;
 
     override public function new(path:String){
         super();
         setVariables();
 
-        parser = new Parser();
+        var parser = new Parser();
         parser.allowJSON = parser.allowMetadata = parser.allowTypes = true;
         
-        var scriptStrings = Utils.getTextInLines(path);
-        
         var scriptToRun:String = "";
-        for (line in scriptStrings){
+        //custom "parser" cuz i'm so lazy
+        for (line in Utils.getTextInLines(path)){
             switch(line.split(" ")[0]){
                 case "import":
                     importClass(line.split("import ")[1].split(";")[0]);
                     line = "//import " + line.split("import ")[1];
             }
-            
+
             scriptToRun += line + "\n";
         }
 
-        var parsedScript = parser.parseString(scriptToRun);
-        execute(parsedScript);
+        execute(parser.parseString(scriptToRun));
     }
 
     //call Function in Interp
     public function callFunc(func:String, ?args:Array<Dynamic>):Dynamic {
 		if (variables.exists(func)) {
-			if (args == null) args = [];
+			if (args == null){ args = []; }
+
 			try {
 				return Reflect.callMethod(null, variables.get(func), args);
 			}
@@ -60,6 +63,7 @@ class Script extends Interp
         variables.set(className, Type.resolveClass(classPath));
 	}
 
+    //import some default classes
     private function setVariables(){
         importClass("Paths");
         importClass("Character");
@@ -74,7 +78,6 @@ class Script extends Interp
 		variables.set('remove', flixel.FlxG.state.remove);
     }
 
-    //get Parents var too
     override public function resolve(id:String):Dynamic {
 		if (parent != null) {
             var instanceFields = Type.getInstanceFields(Type.getClass(parent));

--- a/source/scripts/ScriptableScript.hx
+++ b/source/scripts/ScriptableScript.hx
@@ -1,4 +1,0 @@
-package scripts;
-
-@:hscriptClass
-class ScriptableScript extends Script implements polymod.hscript.HScriptedClass{}


### PR DESCRIPTION
This is an replacement of ScriptableScript that loads scripts from a single ".hxc" file instead of creating new classes.
This can simplify script structure since it don't have to define different class names one by one.

The Script class is replaced by an improved version of Hscript's Interp class.
This improved version includes import functionality not found in the original Hscript, as well as additional functionality to get/set objects from the current instance.

For example, the code to implement the Botplay mode could look like this:
```haxe
function update(e:Float){
    scoreTxt.text = "BOTPLAY";
}

function updateNote(note:Note){
    if (note.mustPress && note.y <= playerStrums.members[Math.floor(Math.abs(note.noteData))].y){
        boyfriend.holdTimer = 0;

        goodNoteHit(note);
    }
}
```
As you can see, you can change values ​​such as scoreTxt directly and also call PlayState functions.
#### Other bug fixes/Tweaks (From a PR that was closed by mistake)
- Fixed Util's readDirectory refusing to add files on some OS
- The method of enabling/disabling mods in Polymod has been replaced with the Polymod recommended method of using loadMods() and unloadAllMods(). (This is slightly faster as you don't need to call Polymod.init() again)