### PR TITLE
Use lavycat's `lime` fork for actual uncapped framerate

### DIFF
--- a/art/scripts/optimize_images.bat
+++ b/art/scripts/optimize_images.bat
@@ -2,8 +2,7 @@
 rem This script goes through every .png in the images folder and optimizes it to reduce file size.
 rem This requires oxipng to run. If you don't have it you can get it here: https://github.com/shssoichiro/oxipng/releases
 rem This will take a lil' bit to run so be prepared to wait while it does it's thing.
-cd..
-cd..
+cd../..
 cd assets/images
 for /R %%f in (*.png) do oxipng -o 6 --strip all --alpha "%%f"
 pause

--- a/hmm.json
+++ b/hmm.json
@@ -1,109 +1,121 @@
 {
-    "dependencies": [
-        {
-            "name": "openfl",
-            "type": "haxelib",
-            "version": null
-        },
-        {
-            "name": "lime",
-            "type": "haxelib",
-            "version": null
-        },
-        {
-            "name": "flixel",
-            "type": "haxelib",
-            "version": null
-        },
-        {
-            "name": "flixel-addons",
-            "type": "haxelib",
-            "version": null
-        },
-        {
-            "name": "flixel-ui",
-            "type": "haxelib",
-            "version": null
-        },
-        {
-            "name": "compiletime",
-            "type": "haxelib",
-            "version": null
-        },
-        {
-            "name": "hxcpp",
-            "type": "haxelib",
-            "version": null
-        },
-        {
-            "name": "flxanimate",
-            "type": "git",
-            "dir": null,
-            "ref": "35692ff335033aa4e6e52ae498d32479053d6256",
-            "url": "https://github.com/Dot-Stuff/flxanimate"
-        },
-        {
-            "name": "funkin.vis",
-            "type": "git",
-            "dir": null,
-            "ref": "d5361037efa3a02c4ab20b5bd14ca11e7d00f519",
-            "url": "https://github.com/FunkinCrew/funkVis"
-        },
-        {
-            "name": "grig.audio",
-            "type": "git",
-            "dir": null,
-            "ref": "57f5d47f2533fd0c3dcd025a86cb86c0dfa0b6d2",
-            "url": "https://gitlab.com/haxe-grig/grig.audio.git"
-        },
-        {
-            "name": "hxCodec",
-            "type": "git",
-            "dir": null,
-            "ref": "61b98a7a353b7f529a8fec84ed9afc919a2dffdd",
-            "url": "https://github.com/FunkinCrew/hxCodec"
-        },
-        {
-            "name": "polymod",
-            "type": "git",
-            "dir": null,
-            "ref": "0fbdf27fe124549730accd540cec8a183f8652c0",
-            "url": "https://github.com/larsiusprime/polymod"
-        },
-        {
-            "name": "jsonpatch",
-            "type": "git",
-            "dir": null,
-            "ref": "f9b83215acd586dc28754b4ae7f69d4c06c3b4d3",
-            "url": "https://github.com/EliteMasterEric/jsonpatch"
-        },
-        {
-            "name": "jsonpath",
-            "type": "git",
-            "dir": null,
-            "ref": "7a24193717b36393458c15c0435bb7c4470ecdda",
-            "url": "https://github.com/EliteMasterEric/jsonpath"
-        },
-        {
-            "name": "thx.core",
-            "type": "git",
-            "dir": null,
-            "ref": "76d87418fadd92eb8e1b61f004cff27d656e53dd",
-            "url": "https://github.com/fponticelli/thx.core"
-        },
-        {
-            "name": "thx.semver",
-            "type": "git",
-            "dir": null,
-            "ref": "bdb191fe7cf745c02a980749906dbf22719e200b",
-            "url": "https://github.com/fponticelli/thx.semver"
-        },
-        {
-            "name": "hscript",
-            "type": "git",
-            "dir": null,
-            "ref": "12785398e2f07082f05034cb580682e5671442a2",
-            "url": "https://github.com/FunkinCrew/hscript"
-        }
-    ]
+  "dependencies": [
+    {
+      "name": "compiletime",
+      "type": "haxelib",
+      "version": null
+    },
+    {
+      "name": "flixel",
+      "type": "haxelib",
+      "version": null
+    },
+    {
+      "name": "flixel-addons",
+      "type": "haxelib",
+      "version": null
+    },
+    {
+      "name": "flixel-ui",
+      "type": "haxelib",
+      "version": null
+    },
+    {
+      "name": "flxanimate",
+      "type": "git",
+      "dir": null,
+      "ref": "35692ff335033aa4e6e52ae498d32479053d6256",
+      "url": "https://github.com/Dot-Stuff/flxanimate"
+    },
+    {
+      "name": "format",
+      "type": "haxelib",
+      "version": null
+    },
+    {
+      "name": "funkin.vis",
+      "type": "git",
+      "dir": null,
+      "ref": "d5361037efa3a02c4ab20b5bd14ca11e7d00f519",
+      "url": "https://github.com/FunkinCrew/funkVis"
+    },
+    {
+      "name": "grig.audio",
+      "type": "git",
+      "dir": null,
+      "ref": "57f5d47f2533fd0c3dcd025a86cb86c0dfa0b6d2",
+      "url": "https://gitlab.com/haxe-grig/grig.audio.git"
+    },
+    {
+      "name": "hscript",
+      "type": "git",
+      "dir": null,
+      "ref": "12785398e2f07082f05034cb580682e5671442a2",
+      "url": "https://github.com/FunkinCrew/hscript"
+    },
+    {
+      "name": "hxCodec",
+      "type": "git",
+      "dir": null,
+      "ref": "61b98a7a353b7f529a8fec84ed9afc919a2dffdd",
+      "url": "https://github.com/FunkinCrew/hxCodec"
+    },
+    {
+      "name": "hxcpp",
+      "type": "haxelib",
+      "version": null
+    },
+    {
+      "name": "hxp",
+      "type": "haxelib",
+      "version": null
+    },
+    {
+      "name": "jsonpatch",
+      "type": "git",
+      "dir": null,
+      "ref": "f9b83215acd586dc28754b4ae7f69d4c06c3b4d3",
+      "url": "https://github.com/EliteMasterEric/jsonpatch"
+    },
+    {
+      "name": "jsonpath",
+      "type": "git",
+      "dir": null,
+      "ref": "7a24193717b36393458c15c0435bb7c4470ecdda",
+      "url": "https://github.com/EliteMasterEric/jsonpath"
+    },
+    {
+      "name": "lime",
+      "type": "git",
+      "dir": null,
+      "ref": "develop",
+      "url": "https://github.com/lavycat/lime.git"
+    },
+    {
+      "name": "openfl",
+      "type": "haxelib",
+      "version": null
+    },
+    {
+      "name": "polymod",
+      "type": "git",
+      "dir": null,
+      "ref": "0fbdf27fe124549730accd540cec8a183f8652c0",
+      "url": "https://github.com/larsiusprime/polymod"
+    },
+    {
+      "name": "thx.core",
+      "type": "git",
+      "dir": null,
+      "ref": "76d87418fadd92eb8e1b61f004cff27d656e53dd",
+      "url": "https://github.com/fponticelli/thx.core"
+    },
+    {
+      "name": "thx.semver",
+      "type": "git",
+      "dir": null,
+      "ref": "bdb191fe7cf745c02a980749906dbf22719e200b",
+      "url": "https://github.com/fponticelli/thx.semver"
+    }
+  ]
 }

--- a/hmm.json
+++ b/hmm.json
@@ -88,7 +88,7 @@
       "name": "lime",
       "type": "git",
       "dir": null,
-      "ref": "develop",
+      "ref": "836ac815d1cf13e34626d77b359818af794f3c90",
       "url": "https://github.com/lavycat/lime.git"
     },
     {


### PR DESCRIPTION
With @lavycat's `lime` fork, FPS+ can finally reach its full potential.

Even with PlayState's FPS capped to 1000, frametimes are FAR more consistent than regular `lime`. (~1ms on my end)

I would recommend uncapping the framerate *everywhere*, so FPS+ can *actually* be FPS+.

I didn't wanna mess with the codebase in terms of how FPS is handled between states, that'll be up to you to edit and test.

> [!NOTE]
> Had to add `hxp` and `format` to the list of libraries in `hmm.json` as the fork uses them.

> [!IMPORTANT]
> When running `lime build <platform` or `lime test <platform>`, it'll have to build a `lime.ndll` file from the ground up, which takes extra time. Once it finishes, it'll compile the engine itself.