### PR TITLE
Local Cache (+ GPU image loading)

### DIFF
--- a/assets/data/events/CharacterAnimationEvents.hxc
+++ b/assets/data/events/CharacterAnimationEvents.hxc
@@ -133,18 +133,15 @@ class CharacterAnimationEvents extends Events
                     newCharacter.applyShader(boyfriend.getShader());
                 }
 
-                playstate.characterLayer.remove(playstate.boyfriend);
+                playstate.characterLayer.replace(playstate.boyfriend, newCharacter);
                 playstate.boyfriend = newCharacter;
-                playstate.characterLayer.add(playstate.boyfriend);
 
-                if(!boyfriend.debugMode && boyfriend.characterInfo.info.functions.add != null){
+                if(boyfriend.characterInfo.info.functions.add != null){
                     boyfriend.characterInfo.info.functions.add(boyfriend);
                 }
 
             case "dad":
                 if (dad.charClass == args[1]){ return; }
-
-                playstate.characterLayer.remove(dad);
 
                 var newCharacter = new Character(dad.x - dad.repositionPoint.x, dad.y - dad.repositionPoint.y, args[1]);
                 playstate.iconP2.setIconCharacter(newCharacter.iconName);
@@ -158,18 +155,15 @@ class CharacterAnimationEvents extends Events
                     newCharacter.applyShader(dad.getShader());
                 }
 
-                playstate.characterLayer.remove(playstate.dad);
+                playstate.characterLayer.replace(playstate.dad, newCharacter);
                 playstate.dad = newCharacter;
-                playstate.characterLayer.add(playstate.dad);
 
-                if(!dad.debugMode && dad.characterInfo.info.functions.add != null){
+                if(dad.characterInfo.info.functions.add != null){
                     dad.characterInfo.info.functions.add(dad);
                 }
 
             case "gf":
                 if (gf.charClass == args[1]){ return; }
-
-                playstate.gfLayer.remove(gf);
 
                 var newCharacter = new Character(gf.x - gf.repositionPoint.x, gf.y - gf.repositionPoint.y, args[1], false, true);
 
@@ -182,14 +176,15 @@ class CharacterAnimationEvents extends Events
                     newCharacter.applyShader(gf.getShader());
                 }
 
-                playstate.characterLayer.remove(playstate.gf);
+                playstate.gfLayer.replace(playstate.gf, newCharacter);
                 playstate.gf = newCharacter;
-                playstate.characterLayer.add(playstate.gf);
 
-                if(!gf.debugMode && gf.characterInfo.info.functions.add != null){
+                if(gf.characterInfo.info.functions.add != null){
                     gf.characterInfo.info.functions.add(gf);
                 }
         }
+
+        playstate.healthBar.createFilledBar(dad.characterColor, boyfriend.characterColor);
     }
 
     var cachedCharacters:Array<String> = [];

--- a/assets/data/events/CharacterAnimationEvents.hxc
+++ b/assets/data/events/CharacterAnimationEvents.hxc
@@ -133,11 +133,11 @@ class CharacterAnimationEvents extends Events
                     newCharacter.applyShader(boyfriend.getShader());
                 }
 
-                playstate.characterLayer.replace(playstate.newCharacter, newCharacter);
-                playstate.newCharacter = newCharacter;
+                playstate.characterLayer.replace(playstate.boyfriend, newCharacter);
+                playstate.boyfriend = newCharacter;
 
-                if(newCharacter.characterInfo.info.functions.add != null){
-                    newCharacter.characterInfo.info.functions.add(newCharacter);
+                if(boyfriend.characterInfo.info.functions.add != null){
+                    boyfriend.characterInfo.info.functions.add(boyfriend);
                 }
 
             case "dad":
@@ -158,8 +158,8 @@ class CharacterAnimationEvents extends Events
                 playstate.characterLayer.replace(playstate.dad, newCharacter);
                 playstate.dad = newCharacter;
 
-                if(newCharacter.characterInfo.info.functions.add != null){
-                    newCharacter.characterInfo.info.functions.add(newCharacter);
+                if(dad.characterInfo.info.functions.add != null){
+                    dad.characterInfo.info.functions.add(dad);
                 }
 
             case "gf":
@@ -179,8 +179,8 @@ class CharacterAnimationEvents extends Events
                 playstate.gfLayer.replace(playstate.gf, newCharacter);
                 playstate.gf = newCharacter;
 
-                if(newCharacter.characterInfo.info.functions.add != null){
-                    newCharacter.characterInfo.info.functions.add(newCharacter);
+                if(gf.characterInfo.info.functions.add != null){
+                    gf.characterInfo.info.functions.add(gf);
                 }
         }
 
@@ -191,8 +191,7 @@ class CharacterAnimationEvents extends Events
     var cachedCharacters:Array<String> = [];
     function changeCharacterPreprocess(tag:String):Void{
         var args = Events.getArgs(tag, ["bf", "Bf", "true"]);
-        if (!cachedCharacters.contains(args[1]))
-        {
+        if (!cachedCharacters.contains(args[1])){
             var cache = new Character(0, 0, args[1]);
             cachedCharacters.push(args[1]);
         }

--- a/assets/data/events/CharacterAnimationEvents.hxc
+++ b/assets/data/events/CharacterAnimationEvents.hxc
@@ -133,11 +133,11 @@ class CharacterAnimationEvents extends Events
                     newCharacter.applyShader(boyfriend.getShader());
                 }
 
-                playstate.characterLayer.replace(playstate.boyfriend, newCharacter);
-                playstate.boyfriend = newCharacter;
+                playstate.characterLayer.replace(playstate.newCharacter, newCharacter);
+                playstate.newCharacter = newCharacter;
 
-                if(boyfriend.characterInfo.info.functions.add != null){
-                    boyfriend.characterInfo.info.functions.add(boyfriend);
+                if(newCharacter.characterInfo.info.functions.add != null){
+                    newCharacter.characterInfo.info.functions.add(newCharacter);
                 }
 
             case "dad":
@@ -158,8 +158,8 @@ class CharacterAnimationEvents extends Events
                 playstate.characterLayer.replace(playstate.dad, newCharacter);
                 playstate.dad = newCharacter;
 
-                if(dad.characterInfo.info.functions.add != null){
-                    dad.characterInfo.info.functions.add(dad);
+                if(newCharacter.characterInfo.info.functions.add != null){
+                    newCharacter.characterInfo.info.functions.add(newCharacter);
                 }
 
             case "gf":
@@ -179,12 +179,13 @@ class CharacterAnimationEvents extends Events
                 playstate.gfLayer.replace(playstate.gf, newCharacter);
                 playstate.gf = newCharacter;
 
-                if(gf.characterInfo.info.functions.add != null){
-                    gf.characterInfo.info.functions.add(gf);
+                if(newCharacter.characterInfo.info.functions.add != null){
+                    newCharacter.characterInfo.info.functions.add(newCharacter);
                 }
         }
 
         playstate.healthBar.createFilledBar(dad.characterColor, boyfriend.characterColor);
+        playstate.healthBar.updateFilledBar();
     }
 
     var cachedCharacters:Array<String> = [];

--- a/assets/data/events/CharacterAnimationEvents.hxc
+++ b/assets/data/events/CharacterAnimationEvents.hxc
@@ -192,9 +192,14 @@ class CharacterAnimationEvents extends Events
         }
     }
 
+    var cachedCharacters:Array<String> = [];
     function changeCharacterPreprocess(tag:String):Void{
         var args = Events.getArgs(tag, ["bf", "Bf", "true"]);
-        var cache = new Character(0, 0, args[1]);
+        if (!cachedCharacters.contains(args[1]))
+        {
+            var cache = new Character(0, 0, args[1]);
+            cachedCharacters.push(args[1]);
+        }
     }
 
     function swapCharacters(tag:String):Void{

--- a/source/Main.hx
+++ b/source/Main.hx
@@ -4,9 +4,9 @@ import modding.PolymodHandler;
 import flixel.system.scaleModes.RatioScaleMode;
 import flixel.FlxG;
 import flixel.FlxGame;
-import openfl.display.FPS;
 import openfl.display.Sprite;
 import debug.*;
+import openfl.display.FPS;
 
 class Main extends Sprite
 {

--- a/source/Main.hx
+++ b/source/Main.hx
@@ -1,5 +1,6 @@
 package;
 
+import extensions.openfl.display.FPSExt;
 import modding.PolymodHandler;
 import flixel.system.scaleModes.RatioScaleMode;
 import flixel.FlxG;
@@ -11,7 +12,7 @@ import openfl.display.FPS;
 class Main extends Sprite
 {
 
-	public static var fpsDisplay:FPS;
+	public static var fpsDisplay:FPSExt;
 
 	public static var novid:Bool = false;
 	public static var flippymode:Bool = false;
@@ -29,7 +30,7 @@ class Main extends Sprite
 
 		SaveManager.global();
 
-		fpsDisplay = new FPS(10, 3, 0xFFFFFF);
+		fpsDisplay = new FPSExt(3, 3, 0xFFFFFF);
 		fpsDisplay.visible = true;
 
 		addChild(new FlxGame(0, 0, Startup, 60, 60, true));

--- a/source/MainMenuState.hx
+++ b/source/MainMenuState.hx
@@ -200,6 +200,8 @@ class MainMenuState extends MusicBeatState
 					customTransOut = new InstantTransition();
 					FreeplayState.curSelected = 0;
 					FreeplayState.curCategory = 0;
+					
+					MusicBeatState.keepCache = true;
 					switchState(new FreeplayState(fromMainMenu, camFollow.getPosition()));
 				}
 				

--- a/source/MainMenuState.hx
+++ b/source/MainMenuState.hx
@@ -200,8 +200,7 @@ class MainMenuState extends MusicBeatState
 					customTransOut = new InstantTransition();
 					FreeplayState.curSelected = 0;
 					FreeplayState.curCategory = 0;
-					
-					MusicBeatState.keepCache = true;
+					ImageCache.keepCache = true;
 					switchState(new FreeplayState(fromMainMenu, camFollow.getPosition()));
 				}
 				

--- a/source/MusicBeatState.hx
+++ b/source/MusicBeatState.hx
@@ -5,6 +5,8 @@ import extensions.flixel.FlxUIStateExt;
 
 class MusicBeatState extends FlxUIStateExt
 {
+	public static var keepCache:Bool = false;
+	
 	private var lastBeat:Float = 0;
 	private var lastStep:Float = 0;
 

--- a/source/MusicBeatState.hx
+++ b/source/MusicBeatState.hx
@@ -5,8 +5,6 @@ import extensions.flixel.FlxUIStateExt;
 
 class MusicBeatState extends FlxUIStateExt
 {
-	public static var keepCache:Bool = false;
-	
 	private var lastBeat:Float = 0;
 	private var lastStep:Float = 0;
 

--- a/source/Paths.hx
+++ b/source/Paths.hx
@@ -29,10 +29,18 @@ class Paths
         if(ImageCache.exists(data) && !forceLoadFromDisk){
             return ImageCache.get(data);
         }
-        else{
-            if(!ImageCache.trackedAssets.contains(data)){
-                ImageCache.trackedAssets.push(data);
+        else if(!forceLoadFromDisk){
+            if(ImageCache.localCache.exists(data))
+            {
+                return ImageCache.localCache.get(data);
             }
+            else
+            {
+                return ImageCache.addLocal(data);
+            }
+        }
+        else
+        {
             return data;
         }
     }

--- a/source/Paths.hx
+++ b/source/Paths.hx
@@ -30,17 +30,14 @@ class Paths
             return ImageCache.get(data);
         }
         else if(!forceLoadFromDisk){
-            if(ImageCache.localCache.exists(data))
-            {
+            if(ImageCache.localCache.exists(data)){
                 return ImageCache.localCache.get(data);
             }
-            else
-            {
+            else{
                 return ImageCache.addLocal(data);
             }
         }
-        else
-        {
+        else{
             return data;
         }
     }

--- a/source/PauseSubState.hx
+++ b/source/PauseSubState.hx
@@ -1,5 +1,6 @@
 package;
 
+import caching.*;
 import flixel.tweens.FlxEase;
 import extensions.flixel.FlxTextExt;
 import haxe.Json;
@@ -151,7 +152,7 @@ class PauseSubState extends MusicBeatSubstate
 						
 					case "Restart Song":
 						PlayState.instance.tweenManager.clear();
-						MusicBeatState.keepCache = true;
+						ImageCache.keepCache = true;
 						PlayState.instance.switchState(new PlayState());
 						PlayState.sectionStart = false;
 						PlayState.replayStartCutscene = false;
@@ -163,7 +164,7 @@ class PauseSubState extends MusicBeatSubstate
 	
 					case "Restart Section":
 						PlayState.instance.tweenManager.clear();
-						MusicBeatState.keepCache = true;
+						ImageCache.keepCache = true;
 						PlayState.instance.switchState(new PlayState());
 						PlayState.replayStartCutscene = false;
 						if(PlayState.instance.instSong != null){
@@ -190,7 +191,7 @@ class PauseSubState extends MusicBeatSubstate
 						
 					case "Options":
 						PlayState.instance.tweenManager.clear();
-						MusicBeatState.keepCache = true;
+						ImageCache.keepCache = true;
 						PlayState.instance.switchState(new ConfigMenu());
 						ConfigMenu.exitTo = PlayState;
 						PlayState.replayStartCutscene = false;

--- a/source/PauseSubState.hx
+++ b/source/PauseSubState.hx
@@ -151,6 +151,7 @@ class PauseSubState extends MusicBeatSubstate
 						
 					case "Restart Song":
 						PlayState.instance.tweenManager.clear();
+						MusicBeatState.keepCache = true;
 						PlayState.instance.switchState(new PlayState());
 						PlayState.sectionStart = false;
 						PlayState.replayStartCutscene = false;
@@ -162,6 +163,7 @@ class PauseSubState extends MusicBeatSubstate
 	
 					case "Restart Section":
 						PlayState.instance.tweenManager.clear();
+						MusicBeatState.keepCache = true;
 						PlayState.instance.switchState(new PlayState());
 						PlayState.replayStartCutscene = false;
 						if(PlayState.instance.instSong != null){
@@ -188,6 +190,7 @@ class PauseSubState extends MusicBeatSubstate
 						
 					case "Options":
 						PlayState.instance.tweenManager.clear();
+						MusicBeatState.keepCache = true;
 						PlayState.instance.switchState(new ConfigMenu());
 						ConfigMenu.exitTo = PlayState;
 						PlayState.replayStartCutscene = false;

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -639,7 +639,7 @@ class PlayState extends MusicBeatState
 		// healthBar
 		
 		scoreTxt = new FlxTextExt(healthBarBG.x - 105, (FlxG.height * 0.9) + 36, 800, "", 22);
-		scoreTxt.setFormat(Paths.font("vcr"), 22, FlxColor.WHITE, FlxTextAlign.CENTER, FlxTextBorderStyle.OUTLINE_FAST, FlxColor.BLACK);
+		scoreTxt.setFormat(Paths.font("vcr"), 22, FlxColor.WHITE, FlxTextAlign.CENTER, FlxTextBorderStyle.OUTLINE, FlxColor.BLACK);
 		scoreTxt.scrollFactor.set();
 
 		iconP1 = new HealthIcon(boyfriend.iconName, true);

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -639,12 +639,11 @@ class PlayState extends MusicBeatState
 		// healthBar
 		
 		scoreTxt = new FlxTextExt(healthBarBG.x - 105, (FlxG.height * 0.9) + 36, 800, "", 22);
-		scoreTxt.setFormat(Paths.font("vcr"), 22, FlxColor.WHITE, FlxTextAlign.CENTER, FlxTextBorderStyle.OUTLINE, FlxColor.BLACK);
+		scoreTxt.setFormat(Paths.font("vcr"), 22, FlxColor.WHITE, FlxTextAlign.CENTER, FlxTextBorderStyle.OUTLINE_FAST, FlxColor.BLACK);
 		scoreTxt.scrollFactor.set();
 
 		iconP1 = new HealthIcon(boyfriend.iconName, true);
 		iconP1.y = healthBar.y - (iconP1.height / 2) + iconP1.yOffset;
-		
 
 		iconP2 = new HealthIcon(dad.iconName, false);
 		iconP2.y = healthBar.y - (iconP2.height / 2) + iconP2.yOffset;

--- a/source/Startup.hx
+++ b/source/Startup.hx
@@ -212,8 +212,8 @@ class Startup extends FlxState
             cacheStart = true;
         }
         if(splash.animation.curAnim.finished && splash.animation.curAnim.name == "end"){
+            ImageCache.localCache.clear();
             Utils.gc();
-            ImageCache.trackedAssets = [];
             FlxG.switchState(nextState);  
         }
 

--- a/source/caching/ImageCache.hx
+++ b/source/caching/ImageCache.hx
@@ -61,7 +61,6 @@ class ImageCache
         var data:FlxGraphic = FlxGraphic.fromBitmapData(bitmap, false, path, false);
         data.persist = true; // Disabled because it messes up the map
 
-        trace("cache added: " + path);
         localCache.set(path, data);
         return data;
     }
@@ -79,7 +78,6 @@ class ImageCache
 
         //cleanup local cached assets
         for(key in localCache.keys()){
-            trace("cleaning " + key);
             removeGraphic(localCache.get(key));
 		}
 

--- a/source/caching/ImageCache.hx
+++ b/source/caching/ImageCache.hx
@@ -14,7 +14,12 @@ class ImageCache
     public static var cache:Map<String, FlxGraphic> = new Map<String, FlxGraphic>();
 
     public static function add(path:String):Void{
-        var data:FlxGraphic = FlxGraphic.fromBitmapData(GPUBitmap.create(path));
+        var bitmap = GPUBitmap.create(path);
+    
+        bitmap.lock();
+		bitmap.disposeImage();
+        
+        var data:FlxGraphic = FlxGraphic.fromBitmapData(bitmap);
         data.persist = true;
         data.destroyOnNoUse = false;
 
@@ -29,28 +34,56 @@ class ImageCache
         return cache.exists(path);
     }
 
-    //OpenFL image cache clearing.  ==============================================================================
+    //Local/CPU image caching stuff.      ==============================================================================
 
-    public static var trackedAssets:Array<String> = new Array<String>();
+    public static var localCache:Map<String, FlxGraphic> = new Map<String, FlxGraphic>();
+
+    public static function addLocal(path:String):FlxGraphic{
+        if (!Utils.exists(path))
+            return null;
+        
+        var bitmap:BitmapData = openfl.Assets.getBitmapData(path);
+        if (config.Config.useGPU && bitmap.image != null)
+        {
+            bitmap.lock();
+			if (bitmap.__texture == null)
+			{
+				bitmap.image.premultiplied = true;
+				bitmap.getTexture(FlxG.stage.context3D);
+			}
+			bitmap.getSurface();
+			bitmap.disposeImage();
+			bitmap.image.data = null;
+			bitmap.image = null;
+			bitmap.readable = true;
+        }
+
+        var data:FlxGraphic = FlxGraphic.fromBitmapData(bitmap, false, path, false);
+        data.persist = true; // Disabled because it messes up the map
+
+        trace("cache added: " + path);
+        localCache.set(path, data);
+        return data;
+    }
+
+    //OpenFL image cache clearing.  ==============================================================================
 
     public static function clear(){
         for(key in FlxG.bitmap._cache.keys()){
             if(openfl.Assets.cache.hasBitmapData(key) && !exists(key)){
                 openfl.Assets.cache.removeBitmapData(key);
                 removeGraphic(FlxG.bitmap.get(key));
-                trackedAssets.remove(key);
+                FlxG.bitmap.removeByKey(key);
             }
 		}
 
-        //cleanup leftover assets
-        for(key in trackedAssets){
-            if(openfl.Assets.cache.hasBitmapData(key) && !exists(key)){
-                openfl.Assets.cache.removeBitmapData(key);
-                FlxG.bitmap.get(key).dump();
-            }
+        //cleanup local cached assets
+        for(key in localCache.keys()){
+            trace("cleaning " + key);
+            removeGraphic(localCache.get(key));
 		}
 
-        trackedAssets = [];
+        ImageCache.localCache.clear();
     }
 
     static function removeGraphic(graphic:FlxGraphic){
@@ -59,7 +92,6 @@ class ImageCache
         }
         graphic.bitmap.dispose();
 
-		FlxG.bitmap.remove(graphic);
         graphic.dump();
 		graphic.destroy();
 	}

--- a/source/caching/ImageCache.hx
+++ b/source/caching/ImageCache.hx
@@ -11,6 +11,8 @@ class ImageCache
 
     //GPU image caching stuff.      ==============================================================================
     
+    public static var keepCache:Bool = false;
+    
     public static var cache:Map<String, FlxGraphic> = new Map<String, FlxGraphic>();
 
     public static function add(path:String):Void{

--- a/source/config/CacheReload.hx
+++ b/source/config/CacheReload.hx
@@ -89,8 +89,8 @@ class CacheReload extends FlxState
     override function update(elapsed):Void{
 
         if(songsCached && charactersCached && graphicsCached){
+            ImageCache.localCache.clear();
             Utils.gc();
-            ImageCache.trackedAssets = [];
             FlxG.switchState(nextState);
         }
 

--- a/source/config/Config.hx
+++ b/source/config/Config.hx
@@ -20,6 +20,7 @@ class Config
 	public static var scrollSpeedOverride:Float;
 	public static var showComboBreaks:Bool;
 	public static var showFPS:Bool;
+	public static var useGPU:Bool;
 	public static var extraCamMovement:Bool;
 	public static var camBopAmount:Int;
 	public static var showCaptions:Bool;
@@ -49,6 +50,7 @@ class Config
 		FlxG.save.data.scrollSpeedOverride = -1;
 		FlxG.save.data.showComboBreaks = false;
 		FlxG.save.data.showFPS = false;
+		FlxG.save.data.useGPU = true;
 		FlxG.save.data.extraCamMovement = true;
 		FlxG.save.data.camBopAmount = 0;
 		FlxG.save.data.showCaptions = true;
@@ -80,6 +82,7 @@ class Config
 		scrollSpeedOverride = FlxG.save.data.scrollSpeedOverride;
 		showComboBreaks = FlxG.save.data.showComboBreaks;
 		showFPS = FlxG.save.data.showFPS;
+		useGPU = FlxG.save.data.useGPU;
 		extraCamMovement = FlxG.save.data.extraCamMovement;
 		camBopAmount = FlxG.save.data.camBopAmount;
 		showCaptions = FlxG.save.data.showCaptions;
@@ -107,6 +110,7 @@ class Config
 								scrollSpeedOverrideW:Float,
 								showComboBreaksW:Bool,
 								showFPSW:Bool,
+								useGPUW:Bool,
 								extraCamMovementW:Bool,
 								camBopAmountW:Int,
 								showCaptionsW:Bool,
@@ -133,6 +137,7 @@ class Config
 		FlxG.save.data.scrollSpeedOverride = scrollSpeedOverrideW;
 		FlxG.save.data.showComboBreaks = showComboBreaksW;
 		FlxG.save.data.showFPS = showFPSW;
+		FlxG.save.data.useGPU = useGPUW;
 		FlxG.save.data.extraCamMovement = extraCamMovementW;
 		FlxG.save.data.camBopAmount = camBopAmountW;
 		FlxG.save.data.showCaptions = showCaptionsW;
@@ -180,6 +185,8 @@ class Config
 			FlxG.save.data.showComboBreaks = false;
 		if(FlxG.save.data.showFPS == null)
 			FlxG.save.data.showFPS = false;
+		if(FlxG.save.data.useGPU == null)
+			FlxG.save.data.useGPU = true;
 		if(FlxG.save.data.extraCamMovement == null)
 			FlxG.save.data.extraCamMovement = true;
 		if(FlxG.save.data.camBopAmount == null)

--- a/source/config/Config.hx
+++ b/source/config/Config.hx
@@ -50,7 +50,7 @@ class Config
 		FlxG.save.data.scrollSpeedOverride = -1;
 		FlxG.save.data.showComboBreaks = false;
 		FlxG.save.data.showFPS = false;
-		FlxG.save.data.useGPU = false;
+		FlxG.save.data.useGPU = true;
 		FlxG.save.data.extraCamMovement = true;
 		FlxG.save.data.camBopAmount = 0;
 		FlxG.save.data.showCaptions = true;
@@ -186,7 +186,7 @@ class Config
 		if(FlxG.save.data.showFPS == null)
 			FlxG.save.data.showFPS = false;
 		if(FlxG.save.data.useGPU == null)
-			FlxG.save.data.useGPU = false;
+			FlxG.save.data.useGPU = true;
 		if(FlxG.save.data.extraCamMovement == null)
 			FlxG.save.data.extraCamMovement = true;
 		if(FlxG.save.data.camBopAmount == null)

--- a/source/config/Config.hx
+++ b/source/config/Config.hx
@@ -50,7 +50,7 @@ class Config
 		FlxG.save.data.scrollSpeedOverride = -1;
 		FlxG.save.data.showComboBreaks = false;
 		FlxG.save.data.showFPS = false;
-		FlxG.save.data.useGPU = true;
+		FlxG.save.data.useGPU = false;
 		FlxG.save.data.extraCamMovement = true;
 		FlxG.save.data.camBopAmount = 0;
 		FlxG.save.data.showCaptions = true;
@@ -186,7 +186,7 @@ class Config
 		if(FlxG.save.data.showFPS == null)
 			FlxG.save.data.showFPS = false;
 		if(FlxG.save.data.useGPU == null)
-			FlxG.save.data.useGPU = true;
+			FlxG.save.data.useGPU = false;
 		if(FlxG.save.data.extraCamMovement == null)
 			FlxG.save.data.extraCamMovement = true;
 		if(FlxG.save.data.camBopAmount == null)

--- a/source/config/ConfigMenu.hx
+++ b/source/config/ConfigMenu.hx
@@ -88,6 +88,7 @@ class ConfigMenu extends FlxUIStateExt
     var scrollSpeedValue:Int;
     var showComboBreaksValue:Bool;
     var showFPSValue:Bool;
+    var useGPUValue:Bool;
     var extraCamMovementValue:Bool;
     var camBopAmountValue:Int;
     final camBopAmountTypes:Array<String> = ["on", "reduced", "off"];
@@ -480,6 +481,7 @@ class ConfigMenu extends FlxUIStateExt
 		scrollSpeedValue = Std.int(Config.scrollSpeedOverride * 10);
 		showComboBreaksValue = Config.showComboBreaks;
 		showFPSValue = Config.showFPS;
+        useGPUValue = Config.useGPU;
 		extraCamMovementValue = Config.extraCamMovement;
 		camBopAmountValue = Config.camBopAmount;
 		showCaptionsValue = Config.showCaptions;
@@ -763,6 +765,14 @@ class ConfigMenu extends FlxUIStateExt
             showFPS.setting = ": " + genericOnOff[showFPSValue?0:1];
         }
 
+        var useGPU = new ConfigOption("GPU GRAPHIC", ": " + genericOnOff[useGPUValue?0:1], "Use the GPU for all image loading. (if possible)");
+        useGPU.optionUpdate = function(){
+            if (pressRight || pressLeft || pressAccept) {
+                FlxG.sound.play(Paths.sound('scrollMenu'));
+                useGPUValue = !useGPUValue;
+            }
+            useGPU.setting = ": " + genericOnOff[useGPUValue?0:1];
+        }
 
 
         //MISC
@@ -1067,7 +1077,7 @@ class ConfigMenu extends FlxUIStateExt
 
 
         configOptions = [
-                            [fpsCap, noteSplash, noteGlow, extraCamStuff, camBopStuff, captionsStuff, bgDim, showFPS],
+                            [fpsCap, noteSplash, noteGlow, extraCamStuff, camBopStuff, captionsStuff, bgDim, showFPS, useGPU],
                             [noteOffset, downscroll, centeredNotes, ghostTap, keyBinds],
                             [showMissesSetting, showAccuracyDisplay, comboDisplay, autoPauseSettings, variationsSettings, scrollSpeed, hpGain, hpDrain, cacheSettings]
                         ];
@@ -1075,7 +1085,7 @@ class ConfigMenu extends FlxUIStateExt
     }
 
     function writeToConfig(){
-		Config.write(offsetValue, healthValue / 10.0, healthDrainValue / 10.0, comboValue, downValue, glowValue, randomTapValue, allowedFramerates[framerateValue], dimValue, noteSplashValue, centeredValue, scrollSpeedValue / 10.0, showComboBreaksValue, showFPSValue, extraCamMovementValue, camBopAmountValue, showCaptionsValue, showAccuracyValue, showMissesValue, enableVariationsValue, autoPauseValue);
+		Config.write(offsetValue, healthValue / 10.0, healthDrainValue / 10.0, comboValue, downValue, glowValue, randomTapValue, allowedFramerates[framerateValue], dimValue, noteSplashValue, centeredValue, scrollSpeedValue / 10.0, showComboBreaksValue, showFPSValue, useGPUValue, extraCamMovementValue, camBopAmountValue, showCaptionsValue, showAccuracyValue, showMissesValue, enableVariationsValue, autoPauseValue);
 	}
 
     function resyncLayers():Void {

--- a/source/config/ConfigMenu.hx
+++ b/source/config/ConfigMenu.hx
@@ -765,7 +765,7 @@ class ConfigMenu extends FlxUIStateExt
             showFPS.setting = ": " + genericOnOff[showFPSValue?0:1];
         }
 
-        var useGPU = new ConfigOption("GPU GRAPHIC", ": " + genericOnOff[useGPUValue?0:1], "Use the GPU for all image loading. (if possible)");
+        var useGPU = new ConfigOption("GPU LOADING", ": " + genericOnOff[useGPUValue?0:1], "Load graphics on the GPU if possible. Reduces memory usage but might not work well on lower end machines.");
         useGPU.optionUpdate = function(){
             if (pressRight || pressLeft || pressAccept) {
                 FlxG.sound.play(Paths.sound('scrollMenu'));
@@ -1077,7 +1077,7 @@ class ConfigMenu extends FlxUIStateExt
 
 
         configOptions = [
-                            [fpsCap, noteSplash, noteGlow, extraCamStuff, camBopStuff, captionsStuff, bgDim, showFPS, useGPU],
+                            [fpsCap, noteSplash, noteGlow, extraCamStuff, camBopStuff, captionsStuff, bgDim, useGPU, showFPS],
                             [noteOffset, downscroll, centeredNotes, ghostTap, keyBinds],
                             [showMissesSetting, showAccuracyDisplay, comboDisplay, autoPauseSettings, variationsSettings, scrollSpeed, hpGain, hpDrain, cacheSettings]
                         ];

--- a/source/debug/ChartingState.hx
+++ b/source/debug/ChartingState.hx
@@ -1253,6 +1253,7 @@ class ChartingState extends MusicBeatState
 					
 				PlayState.loadEvents = false;
 		
+				MusicBeatState.keepCache = true;
 				switchState(new PlayState());
 			}
 		

--- a/source/debug/ChartingState.hx
+++ b/source/debug/ChartingState.hx
@@ -475,7 +475,6 @@ class ChartingState extends MusicBeatState
 
 		diffDrop = new FlxUIDropDownMenu(10, 160, FlxUIDropDownMenu.makeStrIdLabelArray(diffNameList, true), function(diff:String)
 		{
-			trace(diff);
 			diffDropFinal = diffList[Std.parseInt(diff)];
 			PlayState.storyDifficulty = Std.parseInt(diff);
 			
@@ -964,10 +963,6 @@ class ChartingState extends MusicBeatState
 
 		if (curStep >= 16 * (curSection + 1) && FlxG.sound.music.playing)
 		{
-			trace(curStep);
-			trace((_song.notes[curSection].lengthInSteps) * (curSection + 1));
-			trace('DUMBSHIT');
-
 			if (_song.notes[curSection + 1] == null)
 			{
 				addSection();
@@ -1135,9 +1130,6 @@ class ChartingState extends MusicBeatState
 		
 				if (FlxG.mouse.overlaps(curRenderedNotes))
 				{
-		
-					trace("Overlapping Notes");
-		
 					curRenderedNotes.forEach(function(note:Note)
 					{
 						if (FlxG.mouse.overlaps(note))
@@ -1148,9 +1140,6 @@ class ChartingState extends MusicBeatState
 				}
 				else if (FlxG.mouse.overlaps(curRenderedEvents))
 				{
-		
-					trace("Overlapping Events");
-		
 					curRenderedEvents.forEach(function(event:EventSprite)
 					{
 						if (FlxG.mouse.overlaps(event))
@@ -1166,9 +1155,6 @@ class ChartingState extends MusicBeatState
 		
 				if (FlxG.mouse.overlaps(curRenderedNotes))
 				{
-		
-					trace("Overlapping Notes");
-		
 					var selected:Bool = false;
 		
 					curRenderedNotes.forEach(function(note:Note)
@@ -1183,9 +1169,6 @@ class ChartingState extends MusicBeatState
 				}
 				else if (FlxG.mouse.overlaps(curRenderedEvents))
 				{
-		
-					trace("Overlapping Events");
-		
 					curRenderedEvents.forEach(function(event:EventSprite)
 					{
 						if (FlxG.mouse.overlaps(event))
@@ -1395,7 +1378,6 @@ class ChartingState extends MusicBeatState
 					PlayState.returnLocation = "freeplay";
 					PlayState.storyWeek = 0;
 					PlayState.overrideInsturmental = "";
-					trace('CUR WEEK' + PlayState.storyWeek);
 					switchState(new PlayState());
 	
 					//lilBf.animation.play("yeah");
@@ -1521,8 +1503,6 @@ class ChartingState extends MusicBeatState
 	{
 		justChanged = true;
 
-		trace('changing section' + sec);
-
 		if (_song.notes[sec] != null)
 		{
 			curSection = sec;
@@ -1579,9 +1559,6 @@ class ChartingState extends MusicBeatState
 			removeDuplicates(curSection);
 	
 			updateGrid();
-		}
-		else{
-			trace("Section does not exist.");
 		}
 		
 	}
@@ -1944,11 +1921,6 @@ class ChartingState extends MusicBeatState
 
 		removeDuplicates(curSection, curSelectedNote);
 
-		trace(noteStrum);
-		trace(curSection);
-		trace("adding \"" + noteType.text + "\" note");
-		trace(_song.notes[curSection].sectionNotes);
-
 		_song.notes[curSection].sectionNotes.sort(sortByNoteStuff);
 
 		updateGrid();
@@ -1972,11 +1944,6 @@ class ChartingState extends MusicBeatState
 	}
 
 	private var daSpacing:Float = 0.3;
-
-	function loadLevel():Void
-	{
-		trace(_song.notes);
-	}
 
 	function getNotes():Array<Dynamic>
 	{

--- a/source/debug/ChartingState.hx
+++ b/source/debug/ChartingState.hx
@@ -1,5 +1,6 @@
 package debug;
 
+import caching.*;
 import stages.ScriptableStage;
 import note.NoteType;
 import characters.CharacterInfoBase;
@@ -1253,7 +1254,7 @@ class ChartingState extends MusicBeatState
 					
 				PlayState.loadEvents = false;
 		
-				MusicBeatState.keepCache = true;
+				ImageCache.keepCache = true;
 				switchState(new PlayState());
 			}
 		

--- a/source/extensions/openfl/display/FPSExt.hx
+++ b/source/extensions/openfl/display/FPSExt.hx
@@ -1,0 +1,71 @@
+package extensions.openfl.display;
+
+import flixel.FlxG;
+import openfl.text.TextField;
+import openfl.text.TextFormat;
+import openfl.system.System;
+
+/**
+	The FPS class provides an easy-to-use monitor to display
+	the current frame rate of an OpenFL project
+**/
+class FPSExt extends TextField
+{
+	/**
+		The current frame rate, expressed using frames-per-second
+	**/
+	public var currentFPS(default, null):Int;
+
+	/**
+		The current memory usage (WARNING: this is NOT your total program memory usage, rather it shows the garbage collector memory)
+	**/
+	public var memoryMegas(get, never):Float;
+
+	@:noCompletion private var times:Array<Float>;
+
+	public function new(x:Float = 10, y:Float = 10, color:Int = 0x000000)
+	{
+		super();
+
+		this.x = x;
+		this.y = y;
+
+		currentFPS = 0;
+		selectable = false;
+		mouseEnabled = false;
+		defaultTextFormat = new TextFormat("_sans", 14, color);
+		autoSize = LEFT;
+		multiline = true;
+		textColor = 0xFFFFFFFF;
+		text = "FPS: ";
+
+		times = [];
+	}
+
+	var deltaTimeout:Float = 0.0;
+
+	// Event Handlers
+	private override function __enterFrame(deltaTime:Float):Void{
+
+		final now:Float = haxe.Timer.stamp() * 1000;
+		times.push(now);
+		while (times[0] < now - 1000) times.shift();
+
+		deltaTimeout += deltaTime;
+        if (deltaTimeout >= 16) {
+            currentFPS = times.length;
+            updateText();
+            deltaTimeout = 0.0;
+            return;
+        }
+
+	}
+
+	public dynamic function updateText():Void { // so people can override it in hscript
+		text = 'FPS: ${currentFPS}'
+		+ '\nMemory: ${flixel.util.FlxStringUtil.formatBytes(memoryMegas)}';
+	}
+
+	inline function get_memoryMegas():Float
+		return cast(System.totalMemory, UInt);
+}

--- a/source/freeplay/FreeplayState.hx
+++ b/source/freeplay/FreeplayState.hx
@@ -279,6 +279,7 @@ class FreeplayState extends MusicBeatState
 						exitAnimation();
 						customTransOut = new InstantTransition();
 						MainMenuState.fromFreeplay = true;
+						MusicBeatState.keepCache = true;
 						new FlxTimer().start(transitionTimeExit + (staggerTimeExit*4), function(t) {
 							switchState(new MainMenuState());
 						});

--- a/source/freeplay/FreeplayState.hx
+++ b/source/freeplay/FreeplayState.hx
@@ -1227,7 +1227,7 @@ class FreeplayState extends MusicBeatState
 		if(Utils.exists(Paths.image("menu/freeplay/skins/" + dj.freeplaySkin + "/" + image, true))){
 			path = "menu/freeplay/skins/" + dj.freeplaySkin + "/" + image;
 		}
-		return Paths.image(path);
+		return Paths.image(path, true);
 	}
 
 	inline function getSparrowPathWithSkin(path:String):flixel.graphics.frames.FlxAtlasFrames{

--- a/source/freeplay/FreeplayState.hx
+++ b/source/freeplay/FreeplayState.hx
@@ -279,7 +279,7 @@ class FreeplayState extends MusicBeatState
 						exitAnimation();
 						customTransOut = new InstantTransition();
 						MainMenuState.fromFreeplay = true;
-						MusicBeatState.keepCache = true;
+						ImageCache.keepCache = true;
 						new FlxTimer().start(transitionTimeExit + (staggerTimeExit*4), function(t) {
 							switchState(new MainMenuState());
 						});

--- a/source/modding/PolymodHandler.hx
+++ b/source/modding/PolymodHandler.hx
@@ -32,6 +32,7 @@ class PolymodHandler
     public static function reload(?restartState:Bool = true):Void{
         reloadScripts();
         //scriptableClassCheck();
+        MusicBeatState.keepCache = true;
         if(restartState){ FlxG.resetState(); }
     }
 

--- a/source/modding/PolymodHandler.hx
+++ b/source/modding/PolymodHandler.hx
@@ -277,8 +277,8 @@ class PolymodHandler
         Polymod.addImportAlias("lime.utils.Assets", Assets);
         Polymod.addImportAlias("openfl.utils.Assets", Assets);
 
-        Polymod.addImportAlias("flash.display.BlendMode", modding.ScriptingUtil.PolyBlendMode);
-        Polymod.addImportAlias("openfl.display.BlendMode", modding.ScriptingUtil.PolyBlendMode);
+        Polymod.addImportAlias("flash.display.BlendMode", modding.ScriptingUtil.BlendMode);
+        Polymod.addImportAlias("openfl.display.BlendMode", modding.ScriptingUtil.BlendMode);
 
         Polymod.addImportAlias("flixel.math.FlxPoint", flixel.math.FlxPoint.FlxBasePoint);
 

--- a/source/modding/PolymodHandler.hx
+++ b/source/modding/PolymodHandler.hx
@@ -1,5 +1,6 @@
 package modding;
 
+import caching.*;
 import openfl.Assets;
 import haxe.Json;
 import polymod.PolymodConfig;
@@ -32,7 +33,7 @@ class PolymodHandler
     public static function reload(?restartState:Bool = true):Void{
         reloadScripts();
         //scriptableClassCheck();
-        MusicBeatState.keepCache = true;
+        ImageCache.keepCache = true;
         if(restartState){ FlxG.resetState(); }
     }
 

--- a/source/modding/ScriptingUtil.hx
+++ b/source/modding/ScriptingUtil.hx
@@ -1,6 +1,6 @@
 package modding;
 
-import openfl.display.BlendMode;
+import openfl.display.BlendMode as BaseBlendMode;
 import flixel.text.FlxText.FlxTextBorderStyle;
 import flixel.input.keyboard.FlxKey;
 import Highscore.Rank;
@@ -60,23 +60,23 @@ class ScriptingUtil
     }
 }
 
-class PolyBlendMode
+class BlendMode
 {
-    public static var ADD = BlendMode.ADD;
-    public static var ALPHA = BlendMode.ALPHA;
-    public static var DARKEN = BlendMode.DARKEN;
-    public static var DIFFERENCE = BlendMode.DIFFERENCE;
-    public static var ERASE = BlendMode.ERASE;
-    public static var HARDLIGHT = BlendMode.HARDLIGHT;
-    public static var INVERT = BlendMode.INVERT;
-    public static var LAYER = BlendMode.LAYER;
-    public static var LIGHTEN = BlendMode.LIGHTEN;
-    public static var MULTIPLY = BlendMode.MULTIPLY;
-    public static var NORMAL = BlendMode.NORMAL;
-    public static var OVERLAY = BlendMode.OVERLAY;
-    public static var SCREEN = BlendMode.SCREEN;
-    public static var SHADER = BlendMode.SHADER;
-    public static var SUBTRACT = BlendMode.SUBTRACT;
+    public static var ADD = BaseBlendMode.ADD;
+    public static var ALPHA = BaseBlendMode.ALPHA;
+    public static var DARKEN = BaseBlendMode.DARKEN;
+    public static var DIFFERENCE = BaseBlendMode.DIFFERENCE;
+    public static var ERASE = BaseBlendMode.ERASE;
+    public static var HARDLIGHT = BaseBlendMode.HARDLIGHT;
+    public static var INVERT = BaseBlendMode.INVERT;
+    public static var LAYER = BaseBlendMode.LAYER;
+    public static var LIGHTEN = BaseBlendMode.LIGHTEN;
+    public static var MULTIPLY = BaseBlendMode.MULTIPLY;
+    public static var NORMAL = BaseBlendMode.NORMAL;
+    public static var OVERLAY = BaseBlendMode.OVERLAY;
+    public static var SCREEN = BaseBlendMode.SCREEN;
+    public static var SHADER = BaseBlendMode.SHADER;
+    public static var SUBTRACT = BaseBlendMode.SUBTRACT;
 }
 
 class FlxTextBorderStyle

--- a/source/transition/BaseTransition.hx
+++ b/source/transition/BaseTransition.hx
@@ -42,15 +42,14 @@ class BaseTransition extends FlxSpriteGroup{
         
         if(state != null){ //State exit animation.
             //FlxG.signals.postStateSwitch.addOnce(Utils.gc);
-            if (!MusicBeatState.keepCache){
-                FlxG.signals.preStateCreate.addOnce(function(state){
+            FlxG.signals.preStateCreate.addOnce(function(state){
+                if(!ImageCache.keepCache){
                     ImageCache.clear();
                     AudioCache.clear();
-                    Utils.gc();
-                });
-            }
-
-            MusicBeatState.keepCache = false; // Make sure to set this to false to avoid clutter
+                    ImageCache.keepCache = false; // Make sure to set this to false to avoid clutter
+                }
+                Utils.gc();
+            });
 
             FlxG.switchState(state);
         }

--- a/source/transition/BaseTransition.hx
+++ b/source/transition/BaseTransition.hx
@@ -42,11 +42,16 @@ class BaseTransition extends FlxSpriteGroup{
         
         if(state != null){ //State exit animation.
             //FlxG.signals.postStateSwitch.addOnce(Utils.gc);
-            FlxG.signals.preStateCreate.addOnce(function(state){
-                ImageCache.clear();
-                AudioCache.clear();
-                Utils.gc();
-            });
+            if (!MusicBeatState.keepCache){
+                FlxG.signals.preStateCreate.addOnce(function(state){
+                    ImageCache.clear();
+                    AudioCache.clear();
+                    Utils.gc();
+                });
+            }
+
+            MusicBeatState.keepCache = false; // Make sure to set this to false to avoid clutter
+
             FlxG.switchState(state);
         }
         else{ //State intro animation.

--- a/source/ui/HealthIcon.hx
+++ b/source/ui/HealthIcon.hx
@@ -76,12 +76,12 @@ class HealthIcon extends FlxSprite
 		//This loads the image, gets it's dimensions, and reloads the image with animation based on cutting up the dimensions.
 		//Basically you can have any size icon as long as it's evenly cut.
 
-		loadGraphic(Paths.image("ui/" + subDir + "/" + icon), false);
+		var graphic = Paths.image("ui/" + subDir + "/" + icon);
 
-		var graphicWidth = Std.int(pixels.width/3);
-		var graphicHeight = Std.int(pixels.height);
+		var graphicWidth = Std.int(graphic.width/3);
+		var graphicHeight = Std.int(graphic.height);
 
-		loadGraphic(pixels, true, graphicWidth, graphicHeight);
+		loadGraphic(graphic, true, graphicWidth, graphicHeight);
 		animation.add("icon", [0, 1, 2], 0, false, isPlayer);
 		animation.play("icon");
 


### PR DESCRIPTION
I created a new caching system by replacing the Flixel cache backend by remade trackedAssets with a map called localCache.
- Added a new option "GPU Graphic" that can change how images are loaded.
- Fixes an issue where "Change Character" events would result in excessive caching.
- Changed Healthicon image loading (slightly) to match the cache system.
- Many other optimizations and performance improvements

### Images (Custom FPS Counter is not included in PR)
Fresh Erect (Default)
<img width="200" alt="スクリーンショット 2025-01-25 11 21 33" src="https://github.com/user-attachments/assets/3970d6e0-9304-487c-93bf-15397bdaf234" />
Fresh Erect (Character and Graphic Cached)
<img width="200" alt="スクリーンショット 2025-01-25 11 18 32" src="https://github.com/user-attachments/assets/2df1dfbf-8d72-400f-a7cc-b0e42efffc40" />
Fresh Erect (GPU Image Option)
<img width="200" alt="スクリーンショット 2025-01-25 11 20 15" src="https://github.com/user-attachments/assets/28d64e90-74b8-4752-8f23-1ce310787d4f" />
Fresh Erect (Before PR, Default)
<img width="200" alt="スクリーンショット 2025-01-25 11 24 28" src="https://github.com/user-attachments/assets/e775e6f9-b677-4828-9c47-95e2c2c8790b" />

The FPS varies because I focused on the window and took the picture immediately.