### PR TITLE
Quick Fix for keepCache

### DIFF
--- a/source/transition/BaseTransition.hx
+++ b/source/transition/BaseTransition.hx
@@ -46,8 +46,8 @@ class BaseTransition extends FlxSpriteGroup{
                 if(!ImageCache.keepCache){
                     ImageCache.clear();
                     AudioCache.clear();
-                    ImageCache.keepCache = false; // Make sure to set this to false to avoid clutter
                 }
+                ImageCache.keepCache = false; // Make sure to set this to false to avoid clutter
                 Utils.gc();
             });
 


### PR DESCRIPTION
keepCache is meant to be used only once, as needed, before switching states, the current location of the code can cause problems such as overly heavy caching.
This quick fix moves keepCache back to its original position so that it can be used the way it was meant to be used.