### PR TITLE
Cancellable Gameplay Event

### DIFF
--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -3,6 +3,7 @@ package;
 import thx.Path;
 import shaders.*;
 import ui.*;
+import data.*;
 import config.*;
 import debug.*;
 import title.*;
@@ -784,12 +785,19 @@ class PlayState extends MusicBeatState
 			startCutscene.start();
 		}
 		else{
+			var countdownEvent = new GameplayEvent("Countdown", true);
 			if(!stage.instantStart){
-				startCountdown();
+				countdownEvent.onEvent.add(startCountdown);
 			}
 			else{
-				instantStart();
+				countdownEvent.onEvent.add(instantStart);
 			}
+
+			countdownEvent.onCancel.add(instantStart);
+
+			for(script in scripts){ script.countdownStart(countdownEvent); }
+
+			countdownEvent.call();
 		}
 		replayStartCutscene = true;
 	}

--- a/source/data/GameplayEvent.hx
+++ b/source/data/GameplayEvent.hx
@@ -1,0 +1,42 @@
+package data;
+
+import flixel.util.FlxSignal;
+import flixel.util.FlxSignal;
+import flixel.FlxG;
+
+/**
+	Not song events or anything like that, just in-game events that can be cancelled or skipped.
+	@author Sulkiez
+**/
+
+class GameplayEvent
+{
+	public var onEvent:FlxSignal = new FlxSignal();
+	public var onCancel:FlxSignal = new FlxSignal();
+
+	public var name:String = "Event";
+	private var cancelable:Bool = true;
+
+	private var canceled:Bool = false;
+
+	public function new(_name:String, _cancelable:Bool){
+		name = _name;
+		cancelable = _cancelable;
+	}
+
+	public function call()
+	{
+		if (!canceled){
+			onEvent.dispatch();
+		}
+	}
+
+	public function cancel()
+	{
+		if (cancelable)
+		{
+			canceled = true;
+			onCancel.dispatch();
+		}
+	}
+}

--- a/source/data/events/NoteEvent.hx
+++ b/source/data/events/NoteEvent.hx
@@ -1,0 +1,19 @@
+package data.events;
+
+import note.*;
+
+class NoteEvent extends GameplayEvent
+{
+	// (maybe) it will be able to do like "event.note"
+	
+	public var note:Note;
+
+	public var character:Character;
+
+	public function new(_note:Note, _character:Character){
+		super("NoteEvent", false);
+
+		note = _note;
+		character = _character;
+	}
+}

--- a/source/scripts/Script.hx
+++ b/source/scripts/Script.hx
@@ -2,6 +2,7 @@ package scripts;
 
 import flixel.FlxG;
 import flixel.FlxBasic;
+import data.GameplayEvent;
 import note.Note;
 
 @:build(modding.GlobalScriptingTypesMacro.build())
@@ -39,6 +40,11 @@ class Script
      * @param   curStep  The current song step passed in by PlayState.
      */
     public function step(curStep:Int){}
+
+    /**
+     * Called once the countdown starts.
+     */
+    public function countdownStart(event:GameplayEvent){}
  
     /**
      * Called once the song starts.


### PR DESCRIPTION
Similar to what the basegame implements, but less advanced (for now).
This PR will allow to freely cancel or call gameplay events such as countdowns via script.
```haxe
public function countdownStart(event){
    event.cancel(); // Ignores the startCountdown call and calls instantStart
}
```
The backend is almost complete so I won't make it a draft, but only the countdown has been implemented so far.
I would also like to migrate events such as note hits, but that is outside the scope of this PR as it would break some scripts.