### PR TITLE
use `totalMemoryNumber` instead in memory calculation

### DIFF
--- a/source/extensions/openfl/display/FPSExt.hx
+++ b/source/extensions/openfl/display/FPSExt.hx
@@ -67,5 +67,5 @@ class FPSExt extends TextField
 	}
 
 	inline function get_memoryMegas():Float
-		return cast(System.totalMemory, UInt);
+		return System.totalMemoryNumber;
 }


### PR DESCRIPTION
which is better cuz if the memory goes over int limit memory becomes minus

https://github.com/openfl/openfl/blob/b1dbee822b4109315579294fe2857454dd184f31/src/openfl/system/System.hx#L83-L96