### PR TITLE
Special Animation and the ability to preserve it

### DIFF
--- a/assets/data/events/CharacterAnimationEvents.hxc
+++ b/assets/data/events/CharacterAnimationEvents.hxc
@@ -20,18 +20,40 @@ class CharacterAnimationEvents extends Events
 		addEvent("swapCharacters", swapCharacters, SWAP_CHARACTER_DESC);
 	}
 
-	function playAnim(tag:String):Void{
-		var args = Events.getArgs(tag, ["bf", "", "false", "false", "0"]);
+	function playAnim(tag:String):Void {
+		var args = Events.getArgs(tag, ["bf", "", "false", "false", "0", "false", "false"]);
 
-		switch(args[0]){
-			case "dad":
-				dad.playAnim(args[1], Events.parseBool(args[2]), Events.parseBool(args[3]), Std.parseInt(args[4]));
-
-			case "gf":
-				gf.playAnim(args[1], Events.parseBool(args[2]), Events.parseBool(args[3]), Std.parseInt(args[4]));
-
-			default:
-				boyfriend.playAnim(args[1], Events.parseBool(args[2]), Events.parseBool(args[3]), Std.parseInt(args[4]));
+	switch (args[0]) {
+		case "dad":
+			dad.playAnim(
+				args[1],
+				Events.parseBool(args[2]),
+				Events.parseBool(args[5]),
+				Events.parseBool(args[3]),
+				Std.parseInt(args[4]),
+				false,
+				Events.parseBool(args[6])
+			); 
+		case "gf":
+			gf.playAnim(
+				args[1],
+				Events.parseBool(args[2]),
+				Events.parseBool(args[5]),
+				Events.parseBool(args[3]),
+				Std.parseInt(args[4]),
+				false,
+				Events.parseBool(args[6])
+			);
+		default:
+			boyfriend.playAnim(
+				args[1],
+				Events.parseBool(args[2]),
+				Events.parseBool(args[5]),
+				Events.parseBool(args[3]),
+				Std.parseInt(args[4]),
+				false,
+				Events.parseBool(args[6])
+			);
 		}
 	}
 
@@ -219,7 +241,7 @@ class CharacterAnimationEvents extends Events
 
 
 	//Event descriptions. Not required but it helps with charting.
-	var PLAY_ANIM_DESC:String = "Plays an animation on a character.\n\nArgs:\n    String: Character (\"bf\", \"dad\", or \"gf\")\n    String: Animation name\n    Bool: Force play animation\n    Bool: Reverse animation\n    Int: Frame to start on";
+	var PLAY_ANIM_DESC:String = "Plays an animation on a character.\n\nArgs:\n    String: Character (\"bf\", \"dad\", or \"gf\")\n    String: Animation name\n    Bool: Force play animation\n    Bool: Reverse animation\n    Int: Frame to start on\n    Bool: Special animation\n    Bool: Preserve special animation";
 	var SING_ANIM_DESC:String = "Plays an animation treated as a note sing direction.\n\nArgs:\n    String: Character (\"bf\", \"dad\", or \"gf\")\n    String: Animation name\n    Bool: Force play animation\n    Bool: Reverse animation\n    Int: Frame to start on";
 	var SET_ANIM_SET_DESC:String = "Sets the animation set on a character.\n\nArgs:\n    String: Character (\"bf\", \"dad\", or \"gf\")\n    String: Animation set suffix";
 	var GF_BOP_FREQ_DESC:String = "Sets the interval that GF does their idle dance.\n\nArgs:\n    Int: Interval (every \"x\" beats)";

--- a/source/Character.hx
+++ b/source/Character.hx
@@ -17,18 +17,20 @@ using StringTools;
 
 class Character extends FlxSpriteGroup
 {
-
-	//Global character properties.
-	public static final LOOP_ANIM_ON_HOLD:Bool = true;		//Determines whether hold notes will loop the sing animation. Default is true.
-	public static final HOLD_LOOP_WAIT:Bool = true;			//Determines whether hold notes will only loop the sing animation if 4 frames of animation have passed. Default is true for FPS Plus, false for base game.
-	public static final USE_IDLE_END:Bool = false;			//Determines whether you will go back to the start of the idle or the end of the idle when letting go of a note. Default is false.
-	public static final PREVENT_SHORT_IDLE:Bool = true;		//Prevents characters from quickly playing a few frames of their idles inbetween hitting notes. Default is true for FPS Plus, false for base game.
-	public static final PREVENT_SHORT_SING:Bool = true;		//Prevents characters from quickly playing a few frames of their sing animation when hitting multiple notes. Default is true for FPS Plus, false for base game.
-	public static final SHORT_SING_TOLERENCE:Float = 20;	//Millisecond tolerence for PREVENT_SHORT_SING detection.
+	// Global character properties.
+	public static final LOOP_ANIM_ON_HOLD:Bool = true; // Determines whether hold notes will loop the sing animation. Default is true.
+	public static final HOLD_LOOP_WAIT:Bool = true; // Determines whether hold notes will only loop the sing animation if 4 frames of animation have passed. Default is true for FPS Plus, false for base game.
+	public static final USE_IDLE_END:Bool = false; // Determines whether you will go back to the start of the idle or the end of the idle when letting go of a note. Default is false.
+	public static final PREVENT_SHORT_IDLE:Bool = true; // Prevents characters from quickly playing a few frames of their idles inbetween hitting notes. Default is true for FPS Plus, false for base game.
+	public static final PREVENT_SHORT_SING:Bool = true; // Prevents characters from quickly playing a few frames of their sing animation when hitting multiple notes. Default is true for FPS Plus, false for base game.
+	public static final SHORT_SING_TOLERENCE:Float = 20; // Millisecond tolerence for PREVENT_SHORT_SING detection.
 
 	public var animOffsets:Map<String, Array<Dynamic>>;
+	public var specialAnim:Bool = false;
+
 	private var originalAnimOffsets:Map<String, Array<Dynamic>>;
 	private var animLoopPoints:Map<String, Int>;
+
 	public var repositionPoint:FlxPoint = new FlxPoint();
 	public var debugMode:Bool = false;
 	public var noLogic:Bool = false;
@@ -67,25 +69,25 @@ class Character extends FlxSpriteGroup
 
 	var character:FlxSprite;
 	var atlasCharacter:AtlasSprite;
+
 	public var characterInfo:CharacterInfoBase;
 
 	var curOffset = new FlxPoint();
 
-	//var added:Bool = false;
-
+	// var added:Bool = false;
 	public var deathSound:String = "gameOver/fnf_loss_sfx";
 	public var deathSong:String = "gameOver/gameOver";
 	public var deathSongEnd:String = "gameOver/gameOverEnd";
 
 	public var onPlayAnim:FlxTypedSignal<(String, Bool, Bool, Int) -> Void> = new FlxTypedSignal();
 	public var onSing:FlxTypedSignal<(String, Bool, Bool, Int) -> Void> = new FlxTypedSignal();
-	public var onDance:FlxTypedSignal<Void -> Void> = new FlxTypedSignal();
+	public var onDance:FlxTypedSignal<Void->Void> = new FlxTypedSignal();
 
 	public var onAnimationFrame:FlxTypedSignal<(String, Int, Int) -> Void> = new FlxTypedSignal();
 	public var onAnimationFinish:FlxTypedSignal<(String) -> Void> = new FlxTypedSignal();
 
-	public function new(x:Float, y:Float, ?_character:String = "Bf", ?_isPlayer:Bool = false, ?_isGirlfriend:Bool = false, ?_enableDebug:Bool = false){
-
+	public function new(x:Float, y:Float, ?_character:String = "Bf", ?_isPlayer:Bool = false, ?_isGirlfriend:Bool = false, ?_enableDebug:Bool = false)
+	{
 		debugMode = _enableDebug;
 		animOffsets = new Map<String, Array<Dynamic>>();
 		originalAnimOffsets = new Map<String, Array<Dynamic>>();
@@ -102,70 +104,89 @@ class Character extends FlxSpriteGroup
 
 		createCharacterFromInfo(charClass);
 
-		if (((facesLeft && !isPlayer) || (!facesLeft && isPlayer)) && !debugMode){
+		if (((facesLeft && !isPlayer) || (!facesLeft && isPlayer)) && !debugMode)
+		{
 			setFlipX(true);
 			swapLeftAndRightAnimations();
 		}
 
-		if(characterInfo.info.frameLoadType != atlas){ //Code for sheet characters
+		if (characterInfo.info.frameLoadType != atlas)
+		{ // Code for sheet characters
 			character.animation.onFinish.add(animationEnd);
 			character.animation.onFrameChange.add(frameUpdate);
 		}
-		else { //Code for atlas characters
+		else
+		{ // Code for atlas characters
 			atlasCharacter.animationEndCallback = animationEnd;
 			atlasCharacter.frameCallback = frameUpdate;
 		}
 
-		if(characterColor == null){
+		if (characterColor == null)
+		{
 			characterColor = (isPlayer) ? 0xFF66FF33 : 0xFFFF0000;
 		}
-
 	}
 
-	override function update(elapsed:Float){
-		
-		if (!debugMode && !noLogic){
-			if (!isPlayer){
-				//opponent stuff
-				if (isSinging){
+	override function update(elapsed:Float)
+	{
+		if (!debugMode && !noLogic)
+		{
+			if (!isPlayer)
+			{
+				// opponent stuff
+				if (isSinging)
+				{
 					holdTimer += elapsed;
 				}
-				else{
+				else
+				{
 					holdTimer = 0;
 				}
-				
-				if (holdTimer >= Conductor.stepCrochet * stepsUntilRelease * 0.001 && canAutoAnim && (PREVENT_SHORT_IDLE ? !PlayState.instance.anyOpponentNoteInRange : true)){
-					if(USE_IDLE_END){ 
-						idleEnd(); 
+
+				if (holdTimer >= Conductor.stepCrochet * stepsUntilRelease * 0.001
+					&& canAutoAnim
+					&& (PREVENT_SHORT_IDLE ? !PlayState.instance.anyOpponentNoteInRange : true))
+				{
+					if (USE_IDLE_END)
+					{
+						idleEnd();
 					}
-					else{ 
-						dance(); 
+					else
+					{
+						dance();
 						danceLockout = true;
 					}
 					holdTimer = 0;
 				}
 			}
-			else{
-				//player stuff
-				if (isSinging){
+			else
+			{
+				// player stuff
+				if (isSinging)
+				{
 					holdTimer += elapsed;
 				}
-				else{
+				else
+				{
 					holdTimer = 0;
 				}
-					
-				if (curAnim.endsWith('miss') && curAnimFinished() && canAutoAnim){
-					if(USE_IDLE_END){ 
-						idleEnd(); 
+
+				if (curAnim.endsWith('miss') && curAnimFinished() && canAutoAnim)
+				{
+					if (USE_IDLE_END)
+					{
+						idleEnd();
 					}
-					else{ 
-						dance(); 
+					else
+					{
+						dance();
 						danceLockout = true;
 					}
 				}
 			}
 
-			if(characterInfo.info.functions.update != null){
+			if (characterInfo.info.functions.update != null)
+			{
 				characterInfo.info.functions.update(this, elapsed);
 			}
 		}
@@ -173,26 +194,32 @@ class Character extends FlxSpriteGroup
 		timeInCurrentAnimation += elapsed;
 
 		super.update(elapsed);
-
 	}
 
-	public function dance(?ignoreDebug:Bool = false):Void{
+	public function dance(?ignoreDebug:Bool = false):Void
+	{
+		if (specialAnim)
+			return; // Early exit if in special animation mode
+
 		if ((!debugMode || ignoreDebug) && !noLogic)
 		{
-
-			if(danceLockout){
+			if (danceLockout)
+			{
 				danceLockout = false;
 				return;
 			}
 
-			if(characterInfo.info.functions.danceOverride != null){
+			if (characterInfo.info.functions.danceOverride != null)
+			{
 				characterInfo.info.functions.danceOverride(this);
 			}
-			else{
+			else
+			{
 				defaultDanceBehavior();
 			}
 
-			if(characterInfo.info.functions.dance != null){
+			if (characterInfo.info.functions.dance != null)
+			{
 				characterInfo.info.functions.dance(this);
 			}
 
@@ -200,43 +227,56 @@ class Character extends FlxSpriteGroup
 		}
 	}
 
-	public function defaultDanceBehavior():Void{
-		if(idleSequence.length > 0){
+	public function defaultDanceBehavior():Void
+	{
+		if (idleSequence.length > 0)
+		{
 			idleSequenceIndex = idleSequenceIndex % idleSequence.length;
 			playAnim(idleSequence[idleSequenceIndex], true);
 			idleSequenceIndex++;
 		}
 	}
 
-	public function idleEnd(?ignoreDebug:Bool = false):Void{
-		if (!debugMode || ignoreDebug){
-			if(characterInfo.info.functions.idleEndOverride != null){
+	public function idleEnd(?ignoreDebug:Bool = false):Void
+	{
+		if (!debugMode || ignoreDebug)
+		{
+			if (characterInfo.info.functions.idleEndOverride != null)
+			{
 				characterInfo.info.functions.idleEndOverride(this);
 			}
-			else{
+			else
+			{
 				defaultIdleEndBehavior();
 			}
 
-			if(characterInfo.info.functions.idleEnd != null){
+			if (characterInfo.info.functions.idleEnd != null)
+			{
 				characterInfo.info.functions.idleEnd(this);
 			}
 		}
 	}
 
-	public function defaultIdleEndBehavior():Void{
-		if(idleSequence.length > 0){
+	public function defaultIdleEndBehavior():Void
+	{
+		if (idleSequence.length > 0)
+		{
 			playAnim(idleSequence[0], true, false, getAnimLength(idleSequence[0]) - 1);
 		}
 	}
 
-	public function beat(curBeat:Int):Void{
-		if(characterInfo.info.functions.beat != null && !noLogic){
+	public function beat(curBeat:Int):Void
+	{
+		if (characterInfo.info.functions.beat != null && !noLogic)
+		{
 			characterInfo.info.functions.beat(this, curBeat);
 		}
 	}
 
-	public function step(curStep:Int):Void{
-		if(characterInfo.info.functions.step != null && !noLogic){
+	public function step(curStep:Int):Void
+	{
+		if (characterInfo.info.functions.step != null && !noLogic)
+		{
 			characterInfo.info.functions.step(this, curStep);
 		}
 	}
@@ -244,51 +284,83 @@ class Character extends FlxSpriteGroup
 	/**
 	 * Plays an animation based on the parameters.
 	 *
-	 * @param	AnimName				The name of the animation you want to play. Will automatic be suffixed with "-" followed by whatever `animSet` is set to if it's not an empty string.
-	 * @param	Force					If `true` it will force the animation to play no matter what. If `false` the animation will only play if it isn't currently playing or is finished.
-	 * @param	Reversed				If `true` the animation will play backwards.
-	 * @param	Frame					The frame number that the animation should start on.
+	 * @param	AnimName				The name of the animation you want to play.
+	 * @param	Force					If `true`, force plays the animation.
+	 * @param	Special					If `true`, blocks other animations until this ends.
+	 * @param	Reversed				If `true`, the animation plays backward.
+	 * @param	Frame					Starting frame of the animation.
 	 * @param	isPartOfLoopingAnim		***DO NOT USE THIS.*** This is used by `Character.hx` to determine if the function is being used to loop an animation.
-	 * 
-	 * @return  						Returns `true` if the animation was played. Returns `false` if the animation wasn't found and could not be played.
+	 * @param	preserveSpecial			If `true`, prevents clearing specialAnim on force.
 	 */
-	public function playAnim(AnimName:String, Force:Bool = false, Reversed:Bool = false, Frame:Int = 0, ?isPartOfLoopingAnim:Bool = false):Bool{
-
-		if(animSet != "" && !isPartOfLoopingAnim){
-			if(animOffsets.exists(AnimName + "-" + animSet)){
+	public function playAnim(AnimName:String, Force:Bool = false, Special:Bool = false, Reversed:Bool = false, Frame:Int = 0,
+			isPartOfLoopingAnim:Bool = false, preserveSpecial:Bool = false):Bool
+	{
+		if (animSet != "" && !isPartOfLoopingAnim)
+		{
+			if (animOffsets.exists(AnimName + "-" + animSet))
+			{
 				AnimName = AnimName + "-" + animSet;
 			}
 		}
 
-		if(characterInfo.info.frameLoadType != atlas){ //Code for sheet characters
-			if(character.animation.getByName(AnimName) == null) { return false; }
+		// Try to play the animation depending on type
+		if (characterInfo.info.frameLoadType != atlas)
+		{
+			if (character.animation.getByName(AnimName) == null)
+				return false;
 			character.animation.play(AnimName, Force, Reversed, Frame);
 		}
-		else{ //Code for atlas characters
-			if(atlasCharacter.animInfoMap.get(AnimName) == null) { return false; }
+		else
+		{
+			if (atlasCharacter.animInfoMap.get(AnimName) == null)
+				return false;
 			atlasCharacter.playAnim(AnimName, Force, Reversed, Frame);
 		}
 
-		//Change/reset variables n stuff
-		if(!isPartOfLoopingAnim){
+		// Update status if not part of a looping call
+		if (!isPartOfLoopingAnim)
+		{
 			curAnim = AnimName;
 			changeOffsets();
 			isSinging = false;
 			timeInCurrentAnimation = 0;
 			onPlayAnim.dispatch(AnimName, Force, Reversed, Frame);
-			if(characterInfo.info.functions.playAnim != null){
+			if (characterInfo.info.functions.playAnim != null)
+			{
 				characterInfo.info.functions.playAnim(this, AnimName);
 			}
 		}
 
-		return true;
+		// Block non-forced animation if we're in specialAnim mode
+		if (specialAnim && !Force && !isPartOfLoopingAnim)
+		{
+			return false;
+		}
 
+		// Clear specialAnim only if forcing and not preserving
+		if (Force && !preserveSpecial && !isPartOfLoopingAnim)
+		{
+			specialAnim = false;
+		}
+
+		// Set specialAnim if requested
+		if (Special)
+		{
+			specialAnim = true;
+		}
+
+		return true;
 	}
 
-	//You can treat any animation as a singing animation instead of requiring "sing" to be in the animation name.
-	public function singAnim(AnimName:String, Force:Bool = false, Reversed:Bool = false, Frame:Int = 0, ?isPartOfLoopingAnim:Bool = false) {
-		var animPlayed:Bool = playAnim(AnimName, Force, Reversed, Frame, isPartOfLoopingAnim);
-		if(animPlayed){
+	// You can treat any animation as a singing animation instead of requiring "sing" to be in the animation name.
+	public function singAnim(AnimName:String, Force:Bool = false, Reversed:Bool = false, Frame:Int = 0, ?isPartOfLoopingAnim:Bool = false)
+	{
+		if (specialAnim && !Force)
+			return;
+
+		var animPlayed:Bool = playAnim(AnimName, Force, false, Reversed, Frame, isPartOfLoopingAnim);
+		if (animPlayed)
+		{
 			isSinging = true;
 			lastSingTime = Conductor.songPosition;
 			onSing.dispatch(AnimName, Force, Reversed, Frame);
@@ -296,61 +368,81 @@ class Character extends FlxSpriteGroup
 		}
 	}
 
-	function changeOffsets() {
-		if (animOffsets.exists(curAnim)) { 
+	function changeOffsets()
+	{
+		if (animOffsets.exists(curAnim))
+		{
 			var animOffset = animOffsets.get(curAnim);
 
 			var xOffsetAdjust:Float = animOffset[0];
-			if(getFlipX()){
+			if (getFlipX())
+			{
 				xOffsetAdjust *= -1;
-				if(characterInfo.info.frameLoadType != atlas){
+				if (characterInfo.info.frameLoadType != atlas)
+				{
 					xOffsetAdjust += getFrameWidth() * getScale().x;
 					xOffsetAdjust -= getWidth();
 				}
 			}
 
 			var yOffsetAdjust:Float = animOffset[1];
-			if(getFlipY()){
+			if (getFlipY())
+			{
 				yOffsetAdjust *= -1;
-				if(characterInfo.info.frameLoadType != atlas){
+				if (characterInfo.info.frameLoadType != atlas)
+				{
 					yOffsetAdjust += getFrameHeight() * getScale().y;
 					yOffsetAdjust -= getHeight();
 				}
 			}
 
 			curOffset.set(-xOffsetAdjust, -yOffsetAdjust);
-
 		}
-		else {
+		else
+		{
 			curOffset.set(0, 0);
 		}
 
 		updateCharacterPostion();
 	}
 
-	public function addOffset(name:String, x:Float = 0, y:Float = 0, ?addToOriginal:Bool = false){
+	public function addOffset(name:String, x:Float = 0, y:Float = 0, ?addToOriginal:Bool = false)
+	{
 		animOffsets[name] = [x, y];
-		if(addToOriginal){ originalAnimOffsets[name] = [x, y]; }
+		if (addToOriginal)
+		{
+			originalAnimOffsets[name] = [x, y];
+		}
 	}
 
-	function animationEnd(name:String){
+	function animationEnd(name:String)
+	{
 		danceLockout = false;
-		
-		if(characterInfo.info.frameLoadType != atlas){ //Code for sheet characters
-			//custom method for looping animations since the anim end callback doesnt run on looped anmations normally
-			if(animLoopPoints.exists(name)){
+
+		// Manual loop point check (non-atlas only)
+		if (characterInfo.info.frameLoadType != atlas)
+		{
+			if (animLoopPoints.exists(name))
+			{
 				playAnim(name, true, false, animLoopPoints.get(name), true);
 			}
 		}
-		//Not needed for atlas since this is built in to the AtlasSprite functionality.
 
-		if(!debugMode){
-			//Checks for and plays a chained animation.
-			if(characterInfo.info.animChains.exists(name)){
+		if (specialAnim)
+		{
+			specialAnim = false;
+		}
+
+		if (!debugMode)
+		{
+			// Avoid chaining animations immediately after a specialAnim ends
+			if (!specialAnim && characterInfo.info.animChains.exists(name))
+			{
 				playAnim(characterInfo.info.animChains.get(name));
 			}
 
-			if(characterInfo.info.functions.animationEnd != null){
+			if (characterInfo.info.functions.animationEnd != null)
+			{
 				characterInfo.info.functions.animationEnd(this, name);
 			}
 		}
@@ -358,29 +450,41 @@ class Character extends FlxSpriteGroup
 		onAnimationFinish.dispatch(name);
 	}
 
-	function frameUpdate(name:String, frameNumber:Int, frameIndex:Int){
+	function frameUpdate(name:String, frameNumber:Int, frameIndex:Int)
+	{
 		changeOffsets();
 
-		if(!debugMode){
-			if(characterInfo.info.functions.frame != null){
+		if (!debugMode)
+		{
+			if (characterInfo.info.functions.frame != null)
+			{
 				characterInfo.info.functions.frame(this, name, frameNumber);
 			}
 		}
-		
+
 		onAnimationFrame.dispatch(name, frameNumber, frameIndex);
 	}
 
-	function createCharacterFromInfo(name:String):Void{
-
-		if(!ScriptableCharacter.listScriptClasses().contains(name)){ name = "Bf"; }
+	function createCharacterFromInfo(name:String):Void
+	{
+		if (!ScriptableCharacter.listScriptClasses().contains(name))
+		{
+			name = "Bf";
+		}
 		characterInfo = ScriptableCharacter.init(name);
 
 		characterInfo.characterReference = this;
 
-		//trace(characterInfo.info);
-		if(characterInfo.info.name != ""){ curCharacter = characterInfo.info.name; }
-		else{ curCharacter = name.toLowerCase(); }
-			
+		// trace(characterInfo.info);
+		if (characterInfo.info.name != "")
+		{
+			curCharacter = characterInfo.info.name;
+		}
+		else
+		{
+			curCharacter = name.toLowerCase();
+		}
+
 		iconName = characterInfo.info.iconName;
 		deathCharacter = characterInfo.info.deathCharacter;
 		characterColor = characterInfo.info.healthColor;
@@ -389,11 +493,18 @@ class Character extends FlxSpriteGroup
 		focusOffset = characterInfo.info.focusOffset;
 		deathOffset = characterInfo.info.deathOffset;
 
-		if(isPlayer){ focusOffset.x *= -1; }
+		if (isPlayer)
+		{
+			focusOffset.x *= -1;
+		}
 
-		if(characterInfo.info.animChains == null){ characterInfo.info.animChains = new Map<String, String>(); }
+		if (characterInfo.info.animChains == null)
+		{
+			characterInfo.info.animChains = new Map<String, String>();
+		}
 
-		switch(characterInfo.info.frameLoadType){
+		switch (characterInfo.info.frameLoadType)
+		{
 			case load(fw, fh):
 				character = new FlxSprite();
 				character.loadGraphic(Paths.image(characterInfo.info.spritePath), true, fw, fh);
@@ -410,8 +521,10 @@ class Character extends FlxSpriteGroup
 				atlasCharacter = new AtlasSprite(0, 0, Paths.getTextureAtlas(characterInfo.info.spritePath));
 		}
 
-		for(x in characterInfo.info.anims){
-			switch(x.type){
+		for (x in characterInfo.info.anims)
+		{
+			switch (x.type)
+			{
 				case frames:
 					character.animation.add(x.name, x.data.frames, x.data.framerate, false, x.data.flipX, x.data.flipY);
 				case prefix:
@@ -423,33 +536,41 @@ class Character extends FlxSpriteGroup
 				case start:
 					atlasCharacter.addAnimationByFrame(x.name, x.data.frames[0], x.data.frames[1], x.data.framerate, x.data.loop.looped, x.data.loop.loopPoint);
 				case startAtLabel:
-					atlasCharacter.addAnimationStartingAtLabel(x.name, x.data.prefix, x.data.frames[0], x.data.framerate, x.data.loop.looped, x.data.loop.loopPoint);
+					atlasCharacter.addAnimationStartingAtLabel(x.name, x.data.prefix, x.data.frames[0], x.data.framerate, x.data.loop.looped,
+						x.data.loop.loopPoint);
 			}
 
-			if(characterInfo.info.frameLoadType != atlas){
-				if(x.data.loop.looped){
-					if(x.data.loop.loopPoint < 0){
+			if (characterInfo.info.frameLoadType != atlas)
+			{
+				if (x.data.loop.looped)
+				{
+					if (x.data.loop.loopPoint < 0)
+					{
 						animLoopPoints.set(x.name, character.animation.getByName(x.name).numFrames + x.data.loop.loopPoint);
 					}
-					else{
+					else
+					{
 						animLoopPoints.set(x.name, x.data.loop.loopPoint);
 					}
 				}
 			}
-			
-			addOffset(x.name, x.data.offset[0], x.data.offset[1], true);
 
+			addOffset(x.name, x.data.offset[0], x.data.offset[1], true);
 		}
 
-		if(characterInfo.info.anims.length > 0){
+		if (characterInfo.info.anims.length > 0)
+		{
 			playAnim(characterInfo.info.anims[0].name);
 			dance();
 		}
 
-		//This should be used if you need to pass any weird non-standard data to the character
-		if(characterInfo.info.extraData != null){
-			for(type => data in characterInfo.info.extraData){
-				switch(type){
+		// This should be used if you need to pass any weird non-standard data to the character
+		if (characterInfo.info.extraData != null)
+		{
+			for (type => data in characterInfo.info.extraData)
+			{
+				switch (type)
+				{
 					case "stepsUntilRelease":
 						stepsUntilRelease = data;
 					case "scale":
@@ -467,104 +588,141 @@ class Character extends FlxSpriteGroup
 					case "worldPopupOffset":
 						worldPopupOffset.set(data[0], data[1]);
 					default:
-						//Do nothing by default.
+						// Do nothing by default.
 				}
 			}
 		}
 
-		if(characterInfo.info.functions.create != null){
+		if (characterInfo.info.functions.create != null)
+		{
 			characterInfo.info.functions.create(this);
 		}
 
-		if(character != null){ 
+		if (character != null)
+		{
 			character.antialiasing = characterInfo.info.antialiasing;
 			add(character);
 		}
-		if(atlasCharacter != null){
+		if (atlasCharacter != null)
+		{
 			atlasCharacter.antialiasing = characterInfo.info.antialiasing;
 			add(atlasCharacter);
 		}
-
 	}
 
-	//Update character scale and adjust the character's offsets
-	public function changeCharacterScale(_scaleX:Float, ?_scaleY:Null<Float> = null):Void{
-		if(debugMode){ return; }
-		if(_scaleY == null){ _scaleY = _scaleX; }
+	// Update character scale and adjust the character's offsets
+	public function changeCharacterScale(_scaleX:Float, ?_scaleY:Null<Float> = null):Void
+	{
+		if (debugMode)
+		{
+			return;
+		}
+		if (_scaleY == null)
+		{
+			_scaleY = _scaleX;
+		}
 
-		if(characterInfo.info.frameLoadType != atlas){ //Code for sheet characters
+		if (characterInfo.info.frameLoadType != atlas)
+		{ // Code for sheet characters
 			character.scale.set(_scaleX, _scaleY);
 			character.updateHitbox();
 			var offsetBase = new FlxPoint(offset.x, offset.y);
-			for(name => pos in animOffsets){
+			for (name => pos in animOffsets)
+			{
 				addOffset(name, offsetBase.x + (originalAnimOffsets.get(name)[0] * _scaleX), offsetBase.y + (originalAnimOffsets.get(name)[1] * _scaleY));
 			}
 		}
-		else{ //Code for atlas characters
+		else
+		{ // Code for atlas characters
 			atlasCharacter.scale.set(_scaleX, _scaleY);
 			atlasCharacter.updateHitbox();
 			var offsetBase = new FlxPoint(offset.x, offset.y);
-			for(name => pos in animOffsets){
+			for (name => pos in animOffsets)
+			{
 				addOffset(name, offsetBase.x + (originalAnimOffsets.get(name)[0] * _scaleX), offsetBase.y + (originalAnimOffsets.get(name)[1] * _scaleY));
 			}
 		}
-		
 	}
 
-	function updateCharacterPostion():Void{
-		if(character != null){ //Code for sheet characters
+	function updateCharacterPostion():Void
+	{
+		if (character != null)
+		{ // Code for sheet characters
 			character.setPosition(x + curOffset.x, y + curOffset.y);
 		}
-		else if(atlasCharacter != null){ //Code for atlas characters
+		else if (atlasCharacter != null)
+		{ // Code for atlas characters
 			atlasCharacter.setPosition(x + curOffset.x, y + curOffset.y);
 		}
 	}
 
-	public function attachCharacter(child:Character, attachedActions:Array<AttachedAction>){
-		if(attachedActions.contains(withDance)){
-			onDance.add(function(){
+	public function attachCharacter(child:Character, attachedActions:Array<AttachedAction>)
+	{
+		if (attachedActions.contains(withDance))
+		{
+			onDance.add(function()
+			{
 				child.dance();
 			});
 		}
-		if(attachedActions.contains(withSing)){
-			onSing.add(function(anim:String, force:Bool, reverse:Bool, frame:Int){
+		if (attachedActions.contains(withSing))
+		{
+			onSing.add(function(anim:String, force:Bool, reverse:Bool, frame:Int)
+			{
 				child.singAnim(anim, force, reverse, frame);
 			});
 		}
-		if(attachedActions.contains(withPlayAnim)){
-			onPlayAnim.add(function(anim:String, force:Bool, reverse:Bool, frame:Int){
+		if (attachedActions.contains(withPlayAnim))
+		{
+			onPlayAnim.add(function(anim:String, force:Bool, reverse:Bool, frame:Int)
+			{
 				child.playAnim(anim, force, reverse, frame);
-			});	
+			});
 		}
 	}
 
-	public function doAction(action:String){
-		if(characterInfo.info.actions == null) { return; }
-		else{
-			if(characterInfo.info.actions.get(action) != null){
+	public function doAction(action:String)
+	{
+		if (characterInfo.info.actions == null)
+		{
+			return;
+		}
+		else
+		{
+			if (characterInfo.info.actions.get(action) != null)
+			{
 				characterInfo.info.actions.get(action)(this);
 			}
-			else{
+			else
+			{
 				trace("Action \"" + action + "\" not found.");
 			}
 		}
 	}
 
-	//Checks if the object has a custom applyShader function and runs that if found. Basically just used for ABot as of right now.
-	public function applyShader(shader:FlxShader):Void{
-		for(member in members){
-			if(Type.getInstanceFields(Type.getClass(member)).contains("applyShader")){
+	// Checks if the object has a custom applyShader function and runs that if found. Basically just used for ABot as of right now.
+	public function applyShader(shader:FlxShader):Void
+	{
+		for (member in members)
+		{
+			if (Type.getInstanceFields(Type.getClass(member)).contains("applyShader"))
+			{
 				Reflect.callMethod(member, Reflect.field(member, "applyShader"), [shader]);
 			}
-			else{ member.shader = shader; }
+			else
+			{
+				member.shader = shader;
+			}
 		}
 	}
 
-	public function reposition():Void{
+	public function reposition():Void
+	{
 		x += repositionPoint.x;
 		y += repositionPoint.y;
 
-		for(member in members){
+		for (member in members)
+		{
 			member.x += repositionPoint.x;
 			member.y += repositionPoint.y;
 		}
@@ -572,36 +730,43 @@ class Character extends FlxSpriteGroup
 		updateCharacterPostion();
 	}
 
-	public function swapLeftAndRightAnimations():Void{
-
+	public function swapLeftAndRightAnimations():Void
+	{
 		var animSetList:Array<String> = [];
 
-		for(k => v in animOffsets){
-			if(k.startsWith("singRIGHT") || k.startsWith("singLEFT")){
+		for (k => v in animOffsets)
+		{
+			if (k.startsWith("singRIGHT") || k.startsWith("singLEFT"))
+			{
 				var split = k.split("-");
-				if(split.length < 2){
-					if(!animSetList.contains("")){
+				if (split.length < 2)
+				{
+					if (!animSetList.contains(""))
+					{
 						animSetList.push("");
 					}
 				}
-				else{
+				else
+				{
 					var setName = "";
-					for(i in 1...split.length){
+					for (i in 1...split.length)
+					{
 						setName += "-" + split[i];
 					}
-					if(!animSetList.contains(setName)){
+					if (!animSetList.contains(setName))
+					{
 						animSetList.push(setName);
 					}
 				}
 			}
 		}
 
-		@:privateAccess{
+		@:privateAccess {
+			if (characterInfo.info.frameLoadType != atlas)
+			{ // Code for sheet characters
 
-			if(characterInfo.info.frameLoadType != atlas){ //Code for sheet characters
-
-				for(set in animSetList){
-
+				for (set in animSetList)
+				{
 					var oldRight = null;
 					var oldRightOffset = null;
 					var oldRightOffsetOriginal = null;
@@ -609,22 +774,26 @@ class Character extends FlxSpriteGroup
 					var oldLeftOffset = null;
 					var oldLeftOffsetOriginal = null;
 
-					if(character.animation.getByName("singRIGHT" + set) != null){
+					if (character.animation.getByName("singRIGHT" + set) != null)
+					{
 						oldRight = character.animation.getByName("singRIGHT" + set);
 						oldRightOffset = animOffsets.get("singRIGHT" + set);
 						oldRightOffsetOriginal = originalAnimOffsets.get("singRIGHT" + set);
 					}
-					if(character.animation.getByName("singLEFT" + set) != null){
+					if (character.animation.getByName("singLEFT" + set) != null)
+					{
 						oldLeft = character.animation.getByName("singLEFT" + set);
 						oldLeftOffset = animOffsets.get("singLEFT" + set);
 						oldLeftOffsetOriginal = originalAnimOffsets.get("singLEFT" + set);
 					}
-					if(oldRight != null){
+					if (oldRight != null)
+					{
 						character.animation._animations.set("singLEFT" + set, oldRight);
 						animOffsets.set("singLEFT" + set, oldRightOffset);
 						originalAnimOffsets.set("singLEFT" + set, oldRightOffsetOriginal);
 					}
-					if(oldLeft != null){
+					if (oldLeft != null)
+					{
 						character.animation._animations.set("singRIGHT" + set, oldLeft);
 						animOffsets.set("singRIGHT" + set, oldLeftOffset);
 						originalAnimOffsets.set("singRIGHT" + set, oldLeftOffsetOriginal);
@@ -637,34 +806,37 @@ class Character extends FlxSpriteGroup
 					var oldLeftOffsetMiss = null;
 					var oldLeftOffsetOriginalMiss = null;
 
-					if(character.animation.getByName("singRIGHTmiss" + set) != null){
+					if (character.animation.getByName("singRIGHTmiss" + set) != null)
+					{
 						oldRightMiss = character.animation.getByName("singRIGHTmiss" + set);
 						oldRightOffsetMiss = animOffsets.get("singRIGHmissT" + set);
 						oldRightOffsetOriginalMiss = originalAnimOffsets.get("singRIGHTmiss" + set);
 					}
-					if(character.animation.getByName("singLEFTmiss" + set) != null){
+					if (character.animation.getByName("singLEFTmiss" + set) != null)
+					{
 						oldLeftMiss = character.animation.getByName("singLEFTmiss" + set);
 						oldLeftOffsetMiss = animOffsets.get("singLEFTmiss" + set);
 						oldLeftOffsetOriginalMiss = originalAnimOffsets.get("singLEFTmiss" + set);
 					}
-					if(oldRightMiss != null){
+					if (oldRightMiss != null)
+					{
 						character.animation._animations.set("singLEFTmiss" + set, oldRightMiss);
 						animOffsets.set("singLEFTmiss" + set, oldRightOffsetMiss);
 						originalAnimOffsets.set("singLEFTmiss" + set, oldRightOffsetOriginalMiss);
 					}
-					if(oldLeftMiss != null){
+					if (oldLeftMiss != null)
+					{
 						character.animation._animations.set("singRIGHTmiss" + set, oldLeftMiss);
 						animOffsets.set("singRIGHTmiss" + set, oldLeftOffsetMiss);
 						originalAnimOffsets.set("singRIGHTmiss" + set, oldLeftOffsetOriginalMiss);
 					}
-					
 				}
-	
 			}
-			else{ //Code for atlas characters
-	
-				for(set in animSetList){
+			else
+			{ // Code for atlas characters
 
+				for (set in animSetList)
+				{
 					var oldRight = null;
 					var oldRightOffset = null;
 					var oldRightOffsetOriginal = null;
@@ -672,22 +844,26 @@ class Character extends FlxSpriteGroup
 					var oldLeftOffset = null;
 					var oldLeftOffsetOriginal = null;
 
-					if(atlasCharacter.animInfoMap.get("singRIGHT" + set) != null){
+					if (atlasCharacter.animInfoMap.get("singRIGHT" + set) != null)
+					{
 						oldRight = atlasCharacter.animInfoMap.get("singRIGHT" + set);
 						oldRightOffset = animOffsets.get("singRIGHT" + set);
 						oldRightOffsetOriginal = originalAnimOffsets.get("singRIGHT" + set);
 					}
-					if(atlasCharacter.animInfoMap.get("singLEFT" + set) != null){
+					if (atlasCharacter.animInfoMap.get("singLEFT" + set) != null)
+					{
 						oldLeft = atlasCharacter.animInfoMap.get("singLEFT" + set);
 						oldLeftOffset = animOffsets.get("singLEFT" + set);
 						oldLeftOffsetOriginal = originalAnimOffsets.get("singLEFT" + set);
 					}
-					if(oldRight != null){
+					if (oldRight != null)
+					{
 						atlasCharacter.animInfoMap.set("singLEFT" + set, oldRight);
 						animOffsets.set("singLEFT" + set, oldRightOffset);
 						originalAnimOffsets.set("singLEFT" + set, oldRightOffsetOriginal);
 					}
-					if(oldLeft != null){
+					if (oldLeft != null)
+					{
 						atlasCharacter.animInfoMap.set("singRIGHT" + set, oldLeft);
 						animOffsets.set("singRIGHT" + set, oldLeftOffset);
 						originalAnimOffsets.set("singRIGHT" + set, oldLeftOffsetOriginal);
@@ -700,229 +876,284 @@ class Character extends FlxSpriteGroup
 					var oldLeftOffsetMiss = null;
 					var oldLeftOffsetOriginalMiss = null;
 
-					if(atlasCharacter.animInfoMap.get("singRIGHTmiss" + set) != null){
+					if (atlasCharacter.animInfoMap.get("singRIGHTmiss" + set) != null)
+					{
 						oldRightMiss = atlasCharacter.animInfoMap.get("singRIGHTmiss" + set);
 						oldRightOffsetMiss = animOffsets.get("singRIGHTmiss" + set);
 						oldRightOffsetOriginalMiss = originalAnimOffsets.get("singRIGHTmiss" + set);
 					}
-					if(atlasCharacter.animInfoMap.get("singLEFTmiss" + set) != null){
+					if (atlasCharacter.animInfoMap.get("singLEFTmiss" + set) != null)
+					{
 						oldLeftMiss = atlasCharacter.animInfoMap.get("singLEFTmiss" + set);
 						oldLeftOffsetMiss = animOffsets.get("singLEFTmiss" + set);
 						oldLeftOffsetOriginalMiss = originalAnimOffsets.get("singLEFTmiss" + set);
 					}
-					if(oldRight != null){
+					if (oldRight != null)
+					{
 						atlasCharacter.animInfoMap.set("singLEFTmiss" + set, oldRightMiss);
 						animOffsets.set("singLEFTmiss" + set, oldRightOffsetMiss);
 						originalAnimOffsets.set("singLEFTmiss" + set, oldRightOffsetOriginalMiss);
 					}
-					if(oldLeft != null){
+					if (oldLeft != null)
+					{
 						atlasCharacter.animInfoMap.set("singRIGHTmiss" + set, oldLeftMiss);
 						animOffsets.set("singRIGHTmiss" + set, oldLeftOffsetMiss);
 						originalAnimOffsets.set("singRIGHTmiss" + set, oldLeftOffsetOriginalMiss);
 					}
-
 				}
-	
 			}
-
 		}
-
 	}
 
-	public function hasAnimation(_name:String):Bool{
+	public function hasAnimation(_name:String):Bool
+	{
 		return animOffsets.exists(_name);
 	}
 
-
-
-	public function setFlipX(value:Bool):Void {
-		if(characterInfo.info.frameLoadType != atlas){ //Code for sheet characters
+	public function setFlipX(value:Bool):Void
+	{
+		if (characterInfo.info.frameLoadType != atlas)
+		{ // Code for sheet characters
 			character.flipX = value;
 		}
-		else{ //Code for atlas characters
+		else
+		{ // Code for atlas characters
 			atlasCharacter.flipX = value;
 		}
 	}
 
-	public function setFlipY(value:Bool):Void {
-		if(characterInfo.info.frameLoadType != atlas){ //Code for sheet characters
+	public function setFlipY(value:Bool):Void
+	{
+		if (characterInfo.info.frameLoadType != atlas)
+		{ // Code for sheet characters
 			character.flipY = value;
 		}
-		else{ //Code for atlas characters
+		else
+		{ // Code for atlas characters
 			atlasCharacter.flipY = value;
 		}
 	}
 
-	public function getFlipX():Bool {
-		if(characterInfo.info.frameLoadType != atlas){ //Code for sheet characters
+	public function getFlipX():Bool
+	{
+		if (characterInfo.info.frameLoadType != atlas)
+		{ // Code for sheet characters
 			return character.flipX;
 		}
-		else{ //Code for atlas characters
+		else
+		{ // Code for atlas characters
 			return atlasCharacter.flipX;
 		}
 	}
 
-	public function getFlipY():Bool {
-		if(characterInfo.info.frameLoadType != atlas){ //Code for sheet characters
+	public function getFlipY():Bool
+	{
+		if (characterInfo.info.frameLoadType != atlas)
+		{ // Code for sheet characters
 			return character.flipY;
 		}
-		else{ //Code for atlas characters
+		else
+		{ // Code for atlas characters
 			return atlasCharacter.flipY;
 		}
 	}
 
-	public function getWidth():Float{
-		if(characterInfo.info.frameLoadType != atlas){ //Code for sheet characters
+	public function getWidth():Float
+	{
+		if (characterInfo.info.frameLoadType != atlas)
+		{ // Code for sheet characters
 			return character.width;
 		}
-		else{ //Code for atlas characters
+		else
+		{ // Code for atlas characters
 			return atlasCharacter.width;
 		}
 	}
 
-	public function getHeight():Float{
-		if(characterInfo.info.frameLoadType != atlas){ //Code for sheet characters
+	public function getHeight():Float
+	{
+		if (characterInfo.info.frameLoadType != atlas)
+		{ // Code for sheet characters
 			return character.height;
 		}
-		else{ //Code for atlas characters
+		else
+		{ // Code for atlas characters
 			return atlasCharacter.height;
 		}
 	}
 
-	public function getFrameWidth():Int{
-		if(characterInfo.info.frameLoadType != atlas){ //Code for sheet characters
+	public function getFrameWidth():Int
+	{
+		if (characterInfo.info.frameLoadType != atlas)
+		{ // Code for sheet characters
 			return character.frameWidth;
 		}
-		else{ //Code for atlas characters
+		else
+		{ // Code for atlas characters
 			return atlasCharacter.frameWidth;
 		}
 	}
 
-	public function getFrameHeight():Int{
-		if(characterInfo.info.frameLoadType != atlas){ //Code for sheet characters
+	public function getFrameHeight():Int
+	{
+		if (characterInfo.info.frameLoadType != atlas)
+		{ // Code for sheet characters
 			return character.frameHeight;
 		}
-		else{ //Code for atlas characters
+		else
+		{ // Code for atlas characters
 			return atlasCharacter.frameHeight;
 		}
 	}
 
-	public function getScale():FlxPoint{
-		if(characterInfo.info.frameLoadType != atlas){ //Code for sheet characters
+	public function getScale():FlxPoint
+	{
+		if (characterInfo.info.frameLoadType != atlas)
+		{ // Code for sheet characters
 			return character.scale;
 		}
-		else{ //Code for atlas characters
+		else
+		{ // Code for atlas characters
 			return atlasCharacter.scale;
 		}
 	}
 
-	public function getAntialising():Bool{
+	public function getAntialising():Bool
+	{
 		return characterInfo.info.antialiasing;
 	}
-	
-	override function getMidpoint(?point:FlxPoint):FlxPoint {
+
+	override function getMidpoint(?point:FlxPoint):FlxPoint
+	{
 		if (point == null)
 			point = FlxPoint.get();
 		return point.set(x + getWidth() * 0.5, y + getHeight() * 0.5);
 	}
 
-	override function getGraphicMidpoint(?point:FlxPoint):FlxPoint {
-		if(characterInfo.info.frameLoadType != atlas){ //Code for sheet characters
+	override function getGraphicMidpoint(?point:FlxPoint):FlxPoint
+	{
+		if (characterInfo.info.frameLoadType != atlas)
+		{ // Code for sheet characters
 			if (point == null)
 				point = FlxPoint.get();
 			return point.set(x + character.frameWidth * 0.5 * getScale().x, y + character.frameHeight * 0.5 * getScale().y);
 		}
-		else{ //Code for atlas characters
+		else
+		{ // Code for atlas characters
 			if (point == null)
 				point = FlxPoint.get();
 			return point.set(x + atlasCharacter.frameWidth * 0.5 * getScale().x, y + atlasCharacter.frameHeight * 0.5 * getScale().y);
 		}
 	}
 
-	public function getAnimLength(name:String):Int{
-		if(characterInfo.info.frameLoadType != atlas){ //Code for sheet characters
+	public function getAnimLength(name:String):Int
+	{
+		if (characterInfo.info.frameLoadType != atlas)
+		{ // Code for sheet characters
 			return character.animation.getByName(name).numFrames;
 		}
-		else{ //Code for atlas characters
+		else
+		{ // Code for atlas characters
 			return atlasCharacter.animInfoMap.get(name).length;
 		}
 	}
 
-	public function curAnimFrame():Int{
-		if(characterInfo.info.frameLoadType != atlas){ //Code for sheet characters
+	public function curAnimFrame():Int
+	{
+		if (characterInfo.info.frameLoadType != atlas)
+		{ // Code for sheet characters
 			return character.animation.curAnim.curFrame;
 		}
-		else{ //Code for atlas characters
+		else
+		{ // Code for atlas characters
 			return atlasCharacter.anim.curFrame - atlasCharacter.animInfoMap.get(curAnim).startFrame;
 		}
 	}
 
-	public function setCurAnimFrame(frameNumber:Int):Void{
-		if(characterInfo.info.frameLoadType != atlas){ //Code for sheet characters
+	public function setCurAnimFrame(frameNumber:Int):Void
+	{
+		if (characterInfo.info.frameLoadType != atlas)
+		{ // Code for sheet characters
 			character.animation.curAnim.curFrame = frameNumber;
 		}
-		else{ //Code for atlas characters
+		else
+		{ // Code for atlas characters
 			atlasCharacter.anim.curFrame = atlasCharacter.animInfoMap.get(curAnim).startFrame + frameNumber;
 		}
 	}
 
-	public function getCurAnimFramerate():Float{
-		if(characterInfo.info.frameLoadType != atlas){ //Code for sheet characters
+	public function getCurAnimFramerate():Float
+	{
+		if (characterInfo.info.frameLoadType != atlas)
+		{ // Code for sheet characters
 			return character.animation.curAnim.frameRate;
 		}
-		else{ //Code for atlas characters
+		else
+		{ // Code for atlas characters
 			return atlasCharacter.anim.framerate;
 		}
 	}
 
-	public function curAnimFinished():Bool{
-		if(characterInfo.info.frameLoadType != atlas){ //Code for sheet characters
+	public function curAnimFinished():Bool
+	{
+		if (characterInfo.info.frameLoadType != atlas)
+		{ // Code for sheet characters
 			return character.animation.curAnim.finished;
 		}
-		else{ //Code for atlas characters
+		else
+		{ // Code for atlas characters
 			return !atlasCharacter.anim.isPlaying;
 		}
 	}
 
-	public override function setPosition(X:Float = 0, Y:Float = 0) {
+	public override function setPosition(X:Float = 0, Y:Float = 0)
+	{
 		super.setPosition(X, Y);
 		updateCharacterPostion();
 	}
 
-	override function set_x(Value:Float):Float {
+	override function set_x(Value:Float):Float
+	{
 		x = Value;
 		updateCharacterPostion();
 		return Value;
 	}
 
-	override function set_y(Value:Float):Float {
+	override function set_y(Value:Float):Float
+	{
 		y = Value;
 		updateCharacterPostion();
 		return Value;
 	}
 
-	public function getSprite():FlxSprite{
-		if(characterInfo.info.frameLoadType != atlas){ //Code for sheet characters
+	public function getSprite():FlxSprite
+	{
+		if (characterInfo.info.frameLoadType != atlas)
+		{ // Code for sheet characters
 			return character;
 		}
-		else{ //Code for atlas characters
+		else
+		{ // Code for atlas characters
 			return atlasCharacter;
 		}
 	}
 
-	public function getShader():FlxShader{
-		if(character != null){ //Code for sheet characters
+	public function getShader():FlxShader
+	{
+		if (character != null)
+		{ // Code for sheet characters
 			return character.shader;
 		}
-		else if(atlasCharacter != null){ //Code for atlas characters
+		else if (atlasCharacter != null)
+		{ // Code for atlas characters
 			return atlasCharacter.shader;
 		}
 		return null;
 	}
-
 }
 
-enum abstract AttachedAction(Int){
+enum abstract AttachedAction(Int)
+{
 	var withDance = 0;
 	var withSing = 1;
 	var withPlayAnim = 2;


### PR DESCRIPTION
The `specialAnim` parameter allows an animation to block other animations until it finishes, such as the idle animation. In contrast, `force:Bool` immediately plays the animation regardless of what's currently playing, but does not stop it from being interrupted later unless `specialAnim` is also enabled.
___________________
The `preserveSpecial` flag determines whether the current specialAnim should continue playing uninterrupted, even if another animation is triggered — unless that next animation is also a specialAnim with force enabled.

`specialAnim = true` → This animation can block others while it's running unless overridden.

`preserveSpecial = true` → If there's a `specialAnim` already playing, ignore any new non-forced animations and let the current one finish.
___________________
`CharacterAnimationEvents` has been updated to support these new parameters.

Example usage:
`playAnim;dad;fancyDance;true;false;0;true;false` 

Parameter Breakdown:
`playAnim;Character;Animation;Force;Reverse;StartFrame;Special;PreserveSpecial`
___________________

If you have anything you want me to change or modify, let me know, I'll try my best to change it.