### PR TITLE
GPU caching v2

### DIFF
--- a/source/GPUBitmap.hx
+++ b/source/GPUBitmap.hx
@@ -1,9 +1,7 @@
 package;
 
-import openfl.display3D.textures.RectangleTexture;
 import openfl.display3D.textures.Texture;
 import openfl.Assets;
-import lime.utils.Assets as LimeAssets;
 import openfl.display.BitmapData;
 import flixel.FlxG;
 import openfl.display3D.Context3DTextureFormat;
@@ -18,8 +16,6 @@ using StringTools;
 
 class GPUBitmap
 {
-	static var trackedTextures:Array<TexAsset> = new Array<TexAsset>();
-
 	/**
 
 		* Creates BitmapData for a sprite and deletes the reference stored in RAM leaving only the texture in VRAM.
@@ -36,53 +32,11 @@ class GPUBitmap
 			_cachekey = path;
 		}
 
-		for (tex in trackedTextures){
-			if (tex.cacheKey == _cachekey){
-				return BitmapData.fromTexture(tex.texture);
-			}
-		}
-
 		var bmp = Assets.getBitmapData(path, false);
 		var _texture = FlxG.stage.context3D.createTexture(bmp.width, bmp.height, texFormat, optimizeForRender);
 		_texture.uploadFromBitmapData(bmp);
 		bmp.dispose();
 		bmp.disposeImage();
-		var trackedTex = new TexAsset(_texture, _cachekey);
-		trackedTextures.push(trackedTex);
 		return BitmapData.fromTexture(_texture);
-	}
-
-	public static function disposeAllTextures():Void{
-		for (texture in trackedTextures){
-			texture.texture.dispose();
-			trackedTextures.remove(texture);
-		}
-	}
-
-	public static function disposeTexturesByKey(key:String){
-		for (i in 0...trackedTextures.length){
-			if (trackedTextures[i].cacheKey.contains(key)){
-				trackedTextures[i].texture.dispose();
-				trackedTextures.remove(trackedTextures[i]);
-			}
-		}
-	}
-
-	public static function disposeAll(){
-		for (i in 0...trackedTextures.length){
-			trackedTextures[i].texture.dispose();
-		}
-		trackedTextures = new Array<TexAsset>();
-	}
-}
-
-class TexAsset
-{
-	public var texture:Texture;
-	public var cacheKey:String;
-
-	public function new(texture:Texture, cacheKey:String){
-		this.texture = texture;
-		this.cacheKey = cacheKey;
 	}
 }

--- a/source/MainMenuState.hx
+++ b/source/MainMenuState.hx
@@ -206,7 +206,6 @@ class MainMenuState extends MusicBeatState
 					customTransOut = new InstantTransition();
 					FreeplayState.curSelected = 0;
 					FreeplayState.curCategory = 0;
-					ImageCache.skipDestroy = true;
 					switchState(new FreeplayState(fromMainMenu, camFollow.getPosition()));
 				}
 				

--- a/source/MainMenuState.hx
+++ b/source/MainMenuState.hx
@@ -206,7 +206,7 @@ class MainMenuState extends MusicBeatState
 					customTransOut = new InstantTransition();
 					FreeplayState.curSelected = 0;
 					FreeplayState.curCategory = 0;
-					ImageCache.keepCache = true;
+					ImageCache.skipDestroy = true;
 					switchState(new FreeplayState(fromMainMenu, camFollow.getPosition()));
 				}
 				

--- a/source/Paths.hx
+++ b/source/Paths.hx
@@ -25,7 +25,7 @@ class Paths
 	inline static public function image(key:String, forcePath:Bool = false):Dynamic{
 		var data:String = file(key, "images", "png");
 
-		if(forcePath) { return data; }
+		if(forcePath || !Utils.exists(data)) { return data; }
 
 		if(ImageCache.exists(data)){
 			return ImageCache.get(data).graphic;

--- a/source/Paths.hx
+++ b/source/Paths.hx
@@ -23,21 +23,15 @@ class Paths
 	}
 
 	inline static public function image(key:String, forcePath:Bool = false):Dynamic{
-
 		var data:String = file(key, "images", "png");
 
 		if(forcePath) { return data; }
 
 		if(ImageCache.exists(data)){
-			return ImageCache.get(data);
+			return ImageCache.get(data).graphic;
 		}
 		else{
-			if(ImageCache.localCache.exists(data)){
-				return ImageCache.localCache.get(data);
-			}
-			else{
-				return ImageCache.addLocal(data);
-			}
+			return ImageCache.loadLocal(data).graphic;
 		}
 	}
 

--- a/source/Paths.hx
+++ b/source/Paths.hx
@@ -25,7 +25,7 @@ class Paths
 	inline static public function image(key:String, forcePath:Bool = false):Dynamic{
 		var data:String = file(key, "images", "png");
 
-		if(forcePath || !Utils.exists(key)) { return data; }
+		if(forcePath) { return data; }
 
 		if(ImageCache.exists(data)){
 			return ImageCache.get(data).graphic;

--- a/source/PauseSubState.hx
+++ b/source/PauseSubState.hx
@@ -155,7 +155,6 @@ class PauseSubState extends MusicBeatSubstate
 						
 					case "Restart Song":
 						PlayState.instance.tweenManager.clear();
-						ImageCache.skipDestroy = true;
 						PlayState.instance.switchState(new PlayState());
 						PlayState.sectionStart = false;
 						PlayState.replayStartCutscene = false;
@@ -167,7 +166,6 @@ class PauseSubState extends MusicBeatSubstate
 	
 					case "Restart Section":
 						PlayState.instance.tweenManager.clear();
-						ImageCache.skipDestroy = true;
 						PlayState.instance.switchState(new PlayState());
 						PlayState.replayStartCutscene = false;
 						if(PlayState.instance.instSong != null){
@@ -194,7 +192,6 @@ class PauseSubState extends MusicBeatSubstate
 						
 					case "Options":
 						PlayState.instance.tweenManager.clear();
-						ImageCache.skipDestroy = true;
 						PlayState.instance.switchState(new ConfigMenu());
 						ConfigMenu.exitTo = PlayState;
 						PlayState.replayStartCutscene = false;

--- a/source/PauseSubState.hx
+++ b/source/PauseSubState.hx
@@ -155,7 +155,7 @@ class PauseSubState extends MusicBeatSubstate
 						
 					case "Restart Song":
 						PlayState.instance.tweenManager.clear();
-						ImageCache.keepCache = true;
+						ImageCache.skipDestroy = true;
 						PlayState.instance.switchState(new PlayState());
 						PlayState.sectionStart = false;
 						PlayState.replayStartCutscene = false;
@@ -167,7 +167,7 @@ class PauseSubState extends MusicBeatSubstate
 	
 					case "Restart Section":
 						PlayState.instance.tweenManager.clear();
-						ImageCache.keepCache = true;
+						ImageCache.skipDestroy = true;
 						PlayState.instance.switchState(new PlayState());
 						PlayState.replayStartCutscene = false;
 						if(PlayState.instance.instSong != null){
@@ -194,7 +194,7 @@ class PauseSubState extends MusicBeatSubstate
 						
 					case "Options":
 						PlayState.instance.tweenManager.clear();
-						ImageCache.keepCache = true;
+						ImageCache.skipDestroy = true;
 						PlayState.instance.switchState(new ConfigMenu());
 						ConfigMenu.exitTo = PlayState;
 						PlayState.replayStartCutscene = false;

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -1934,6 +1934,7 @@ class PlayState extends MusicBeatState
 			vocalsOther.volume = 0; 
 			vocalsOther.pause();
 		}
+		countSteps = false;
 	}
 
 	public function endSong():Void{
@@ -1984,6 +1985,7 @@ class PlayState extends MusicBeatState
 				}
 				var weekName:String = StoryMenuState.weekList[storyWeek].name;
 
+				ImageCache.forceClearOnTransition = true;
 				switchState(new ResultsState(weekStats, weekName, boyfriend.characterInfo.info.resultsCharacter, songSaveStuff, StoryMenuState.weekList[storyWeek].stickerSet));
 
 				//FlxG.save.data.weekUnlocked = StoryMenuState.weekUnlocked;
@@ -2028,11 +2030,13 @@ class PlayState extends MusicBeatState
 					diff: storyDifficulty
 				}
 			}
+			ImageCache.forceClearOnTransition = true;
 			switchState(new ResultsState(songStats, songName, boyfriend.characterInfo.info.resultsCharacter, songSaveStuff));
 		}
 	}
 
 	public function returnToMenu():Void{
+		ImageCache.forceClearOnTransition = true;
 		switch(returnLocation){
 			case "story":
 				switchState(new StoryMenuState());

--- a/source/Startup.hx
+++ b/source/Startup.hx
@@ -42,24 +42,23 @@ class Startup extends FlxUIStateExt
 	var loadTotal:Int = 0;
 
 	var songsCached:Bool;
-	public static var songs(get, never):Array<String>;
-	static function get_songs():Array<String>
-	{
-		var returnArray:Array<String> = [];
-		for (folder in FileSystem.readDirectory("assets/songs")){
-			if (FileSystem.isDirectory(folder) && FileSystem.exists(folder + "/Inst.ogg")){// Check if this is a real song folder
-				returnArray.push(folder);
-			}
-		}
-		return returnArray;
-	}
-
+	public static final songs:Array<String> =   ["Tutorial", 
+								"Bopeebo", "Fresh", "Dadbattle", 
+								"Spookeez", "South", "Monster",
+								"Pico", "Philly", "Blammed", 
+								"Satin-Panties", "High", "Milf", 
+								"Cocoa", "Eggnog", "Winter-Horrorland", 
+								"Senpai", "Roses", "Thorns",
+								"Ugh", "Guns", "Stress",
+								"Darnell", "Lit-Up", "2hot", "Blazin",
+								"Lil-Buddies"];
+								
 	//List of character graphics and some other stuff.
 	//Just in case it want to do something with it later.
 	var charactersCached:Bool;
 	var startCachingCharacters:Bool = false;
 	var charI:Int = 0;
-	public static var characters:Array<String> =   ["BOYFRIEND", "BOYFRIEND_DEAD", "week4/bfCar", "week5/bfChristmas", "week6/bfPixel", "week6/bfPixelsDEAD", "week7/bfAndGF", "week7/bfHoldingGF-DEAD",
+	public static final characters:Array<String> =   ["BOYFRIEND", "BOYFRIEND_DEAD", "week4/bfCar", "week5/bfChristmas", "week6/bfPixel", "week6/bfPixelsDEAD", "week7/bfAndGF", "week7/bfHoldingGF-DEAD",
 									"GF_assets", "week4/gfCar", "week5/gfChristmas", "week6/gfPixel", "week7/gfTankmen",
 									"week1/DADDY_DEAREST", 
 									"week2/spooky_kids_assets", "week2/Monster_Assets",

--- a/source/Startup.hx
+++ b/source/Startup.hx
@@ -42,23 +42,24 @@ class Startup extends FlxUIStateExt
 	var loadTotal:Int = 0;
 
 	var songsCached:Bool;
-	public static final songs:Array<String> =   ["Tutorial", 
-								"Bopeebo", "Fresh", "Dadbattle", 
-								"Spookeez", "South", "Monster",
-								"Pico", "Philly", "Blammed", 
-								"Satin-Panties", "High", "Milf", 
-								"Cocoa", "Eggnog", "Winter-Horrorland", 
-								"Senpai", "Roses", "Thorns",
-								"Ugh", "Guns", "Stress",
-								"Darnell", "Lit-Up", "2hot", "Blazin",
-								"Lil-Buddies"];
-								
+	public static var songs(get, never):Array<String>;
+	static function get_songs():Array<String>
+	{
+		var returnArray:Array<String> = [];
+		for (folder in FileSystem.readDirectory("assets/songs")){
+			if (FileSystem.isDirectory(folder) && FileSystem.exists(folder + "/Inst.ogg")){// Check if this is a real song folder
+				returnArray.push(folder);
+			}
+		}
+		return returnArray;
+	}
+
 	//List of character graphics and some other stuff.
 	//Just in case it want to do something with it later.
 	var charactersCached:Bool;
 	var startCachingCharacters:Bool = false;
 	var charI:Int = 0;
-	public static final characters:Array<String> =   ["BOYFRIEND", "BOYFRIEND_DEAD", "week4/bfCar", "week5/bfChristmas", "week6/bfPixel", "week6/bfPixelsDEAD", "week7/bfAndGF", "week7/bfHoldingGF-DEAD",
+	public static var characters:Array<String> =   ["BOYFRIEND", "BOYFRIEND_DEAD", "week4/bfCar", "week5/bfChristmas", "week6/bfPixel", "week6/bfPixelsDEAD", "week7/bfAndGF", "week7/bfHoldingGF-DEAD",
 									"GF_assets", "week4/gfCar", "week5/gfChristmas", "week6/gfPixel", "week7/gfTankmen",
 									"week1/DADDY_DEAREST", 
 									"week2/spooky_kids_assets", "week2/Monster_Assets",
@@ -261,7 +262,7 @@ class Startup extends FlxUIStateExt
 			}
 			else{
 				if(Utils.exists(Paths.file(characters[charI], "images", "png"))){
-					ImageCache.add(Paths.file(characters[charI], "images", "png"));
+					ImageCache.preload(Paths.file(characters[charI], "images", "png"));
 				}
 				else{
 					trace("Character: File at " + characters[charI] + " not found, skipping cache.");
@@ -279,7 +280,7 @@ class Startup extends FlxUIStateExt
 			}
 			else{
 				if(Utils.exists(Paths.file(graphics[gfxI], "images", "png"))){
-					ImageCache.add(Paths.file(graphics[gfxI], "images", "png"));
+					ImageCache.preload(Paths.file(graphics[gfxI], "images", "png"));
 				}
 				else{
 					trace("Graphic: File at " + graphics[gfxI] + " not found, skipping cache.");
@@ -349,7 +350,7 @@ class Startup extends FlxUIStateExt
 
 	function preloadCharacters(){
 		for(x in characters){
-			ImageCache.add(Paths.file(x, "images", "png"));
+			ImageCache.preload(Paths.file(x, "images", "png"));
 			//trace("Chached " + x);
 		}
 		loadingText.text = "Characters cached...";
@@ -358,7 +359,7 @@ class Startup extends FlxUIStateExt
 
 	function preloadGraphics(){
 		for(x in graphics){
-			ImageCache.add(Paths.file(x, "images", "png"));
+			ImageCache.preload(Paths.file(x, "images", "png"));
 			//trace("Chached " + x);
 		}
 		loadingText.text = "Graphics cached...";

--- a/source/caching/GPUBitmap.hx
+++ b/source/caching/GPUBitmap.hx
@@ -1,4 +1,4 @@
-package;
+package caching;
 
 import openfl.display3D.textures.Texture;
 import openfl.Assets;

--- a/source/caching/ImageCache.hx
+++ b/source/caching/ImageCache.hx
@@ -65,7 +65,6 @@ class ImageCache
 
 	//Local image caching stuff. ==============================================================================
 
-	public static var skipDestroy:Bool = false;
 	public static var localCache:Map<String, GraphicAsset> = new Map<String, GraphicAsset>();
 
 	public static function loadLocal(path:String):GraphicAsset{
@@ -80,11 +79,6 @@ class ImageCache
 	}
 
 	public static function destroyByCount():Void{
-		if(skipDestroy){
-			skipDestroy = false;
-			return;
-		}
-
 		for(key => data in localCache){
 			data.remain -= 1;
 			if(data.autoDestroy && data.remain < 1){

--- a/source/caching/ImageCache.hx
+++ b/source/caching/ImageCache.hx
@@ -38,11 +38,6 @@ class ImageCache
 	public static var preloadCache:Map<String, GraphicAsset> = new Map<String, GraphicAsset>();
 
 	public static function preload(path:String):GraphicAsset{
-		if (!Utils.exists(path)){
-			trace('Tried to preload non-existent graphic ($path)');
-			return GraphicAsset.getPlaceHolderAsset();
-		}
-
 		var graphic = new GraphicAsset(path, false);
 		preloadCache.set(path, graphic);
 		return graphic;
@@ -68,11 +63,6 @@ class ImageCache
 	public static var localCache:Map<String, GraphicAsset> = new Map<String, GraphicAsset>();
 
 	public static function loadLocal(path:String):GraphicAsset{
-		if(!Utils.exists(path)){
-			trace('Tried to cache non-existent graphic ($path)');
-			return GraphicAsset.getPlaceHolderAsset();
-		}
-
 		var graphic = new GraphicAsset(path);
 		localCache.set(path, graphic);
 		return graphic;
@@ -119,11 +109,6 @@ class GraphicAsset implements IFlxDestroyable
 			value = ImageCache.DESTROY_PERIOD;
 		}
 		return remain = value;
-	}
- 
-	public static function getPlaceHolderAsset():GraphicAsset{
-		var placeholderGraphic = flixel.system.FlxAssets.GraphicLogo;
-		return new GraphicAsset("placeholder", true, placeholderGraphic);
 	}
 
 	public function new(key:String, autoDestroy:Bool = true, customBitmap:Dynamic = null){

--- a/source/caching/ImageCache.hx
+++ b/source/caching/ImageCache.hx
@@ -4,6 +4,7 @@ import flixel.graphics.FlxGraphic;
 import flixel.util.FlxDestroyUtil;
 import config.Config;
 import openfl.utils.Assets;
+import caching.GPUBitmap;
 
 class ImageCache
 {
@@ -27,7 +28,7 @@ class ImageCache
 		return preloadCache.exists(path);
 	}
 
-	public static function clearAll(){
+	public static function clearAll():Void{
 		clearPreload();
 		clearLocal();
 	}
@@ -47,37 +48,18 @@ class ImageCache
 		return graphic;
 	}
 
-	public static function clearPreload(){
-		for (key => graphic in preloadCache)
-		{
+	public static function clearPreload():Void{
+		for(key => graphic in preloadCache){
 			removePreload(key);
 		}
 
 		preloadCache.clear();
 	}
 
-	public static function removePreload(key){
-		if (preloadCache.exists(key))
-		{
+	public static function removePreload(key):Void{
+		if(preloadCache.exists(key)){
 			preloadCache.get(key).destroy();
 			preloadCache.remove(key);
-		}
-	}
-
-	public static function destroyByCount(){
-		if (skipDestroy){
-			skipDestroy = false;
-			return;
-		}
-
-		for (key => data in localCache){
-			data.remain -= 1;
-			trace(key + ": " + data.remain);
-
-			if (data.autoDestroy && data.remain < 1){
-				trace("destroyed " + key);
-				removeLocal(key);
-			}
 		}
 	}
 
@@ -87,7 +69,7 @@ class ImageCache
 	public static var localCache:Map<String, GraphicAsset> = new Map<String, GraphicAsset>();
 
 	public static function loadLocal(path:String):GraphicAsset{
-		if (!Utils.exists(path)){
+		if(!Utils.exists(path)){
 			trace('Tried to cache non-existent graphic ($path)');
 			return GraphicAsset.getPlaceHolderAsset();
 		}
@@ -97,18 +79,30 @@ class ImageCache
 		return graphic;
 	}
 
-	public static function clearLocal(){
-		for (key => graphic in localCache){
+	public static function destroyByCount():Void{
+		if(skipDestroy){
+			skipDestroy = false;
+			return;
+		}
+
+		for(key => data in localCache){
+			data.remain -= 1;
+			if(data.autoDestroy && data.remain < 1){
+				removeLocal(key);
+			}
+		}
+	}
+
+	public static function clearLocal():Void{
+		for(key => graphic in localCache){
 			removeLocal(key);
 		}
 
 		localCache.clear();
 	}
 
-
-	public static function removeLocal(key){
-		if (localCache.exists(key))
-		{
+	public static function removeLocal(key):Void{
+		if(localCache.exists(key)){
 			localCache.get(key).destroy();
 			localCache.remove(key);
 		}
@@ -120,18 +114,20 @@ class ImageCache
 class GraphicAsset implements IFlxDestroyable
 {
 	public var key:String;
+
 	public var graphic:FlxGraphic;
 
 	public var autoDestroy:Bool = true;
+
 	public var remain(default, set):Int = ImageCache.DESTROY_PERIOD;
-	function set_remain(value){
-		if (value > ImageCache.DESTROY_PERIOD){
+	function set_remain(value:Int):Int{
+		if(value > ImageCache.DESTROY_PERIOD){
 			value = ImageCache.DESTROY_PERIOD;
 		}
 		return remain = value;
 	}
-
-	public static function getPlaceHolderAsset(){
+ 
+	public static function getPlaceHolderAsset():GraphicAsset{
 		var placeholderGraphic = flixel.system.FlxAssets.GraphicLogo;
 		return new GraphicAsset("placeholder", true, placeholderGraphic);
 	}
@@ -141,11 +137,11 @@ class GraphicAsset implements IFlxDestroyable
 		this.autoDestroy = autoDestroy;
 
 		var bitmap:Dynamic = customBitmap;
-		if (bitmap == null)
-		{
-			if (Config.useGPU){
+		if (bitmap == null){
+			if(Config.useGPU){
 				bitmap = GPUBitmap.create(key);
-			}else{
+			}
+			else{
 				bitmap = Assets.getBitmapData(key, false);
 			}
 		}
@@ -160,7 +156,7 @@ class GraphicAsset implements IFlxDestroyable
 		this.graphic = data;
 	}
 
-	public function destroy(){
+	public function destroy():Void{
 		if(graphic.bitmap.__texture != null){
 			graphic.bitmap.__texture.dispose();
 		}

--- a/source/caching/ImageCache.hx
+++ b/source/caching/ImageCache.hx
@@ -38,6 +38,11 @@ class ImageCache
 	public static var preloadCache:Map<String, GraphicAsset> = new Map<String, GraphicAsset>();
 
 	public static function preload(path:String):GraphicAsset{
+		if (!Utils.exists(path)){
+			trace('Tried to preload non-existent graphic ($path)');
+			return GraphicAsset.getPlaceHolderAsset();
+		}
+
 		var graphic = new GraphicAsset(path, false);
 		preloadCache.set(path, graphic);
 		return graphic;
@@ -63,6 +68,11 @@ class ImageCache
 	public static var localCache:Map<String, GraphicAsset> = new Map<String, GraphicAsset>();
 
 	public static function loadLocal(path:String):GraphicAsset{
+		if(!Utils.exists(path)){
+			trace('Tried to cache non-existent graphic ($path)');
+			return GraphicAsset.getPlaceHolderAsset();
+		}
+
 		var graphic = new GraphicAsset(path);
 		localCache.set(path, graphic);
 		return graphic;
@@ -109,6 +119,11 @@ class GraphicAsset implements IFlxDestroyable
 			value = ImageCache.DESTROY_PERIOD;
 		}
 		return remain = value;
+	}
+ 
+	public static function getPlaceHolderAsset():GraphicAsset{
+		var placeholderGraphic = flixel.system.FlxAssets.GraphicLogo;
+		return new GraphicAsset("placeholder", true, placeholderGraphic);
 	}
 
 	public function new(key:String, autoDestroy:Bool = true, customBitmap:Dynamic = null){

--- a/source/caching/ImageCache.hx
+++ b/source/caching/ImageCache.hx
@@ -8,7 +8,7 @@ import caching.GPUBitmap;
 
 class ImageCache
 {
-	// The grace period before unused local textures are deleted (counted by state switches)
+	//The amount of state switches needed to destroy an asset.
 	inline public static final DESTROY_PERIOD:Int = 2;
 
 	public static function get(path:String):GraphicAsset{
@@ -62,6 +62,8 @@ class ImageCache
 
 	public static var localCache:Map<String, GraphicAsset> = new Map<String, GraphicAsset>();
 
+	public static var forceClearOnTransition:Bool = false;
+
 	public static function loadLocal(path:String):GraphicAsset{
 		var graphic = new GraphicAsset(path);
 		localCache.set(path, graphic);
@@ -89,6 +91,12 @@ class ImageCache
 		if(localCache.exists(key)){
 			localCache.get(key).destroy();
 			localCache.remove(key);
+		}
+	}
+
+	public static function refreshLocal():Void{
+		for(key => value in localCache){
+			value.remain = DESTROY_PERIOD;
 		}
 	}
 }

--- a/source/config/CacheReload.hx
+++ b/source/config/CacheReload.hx
@@ -54,8 +54,7 @@ class CacheReload extends FlxState
 		graphicsCached = !CacheConfig.graphics;
 
 		if(doGraphics){
-			GPUBitmap.disposeAll();
-			ImageCache.cache.clear();
+			ImageCache.clearAll();
 		}
 		else{
 			charactersCached = true;
@@ -102,7 +101,7 @@ class CacheReload extends FlxState
 				charactersCached = true;
 			}
 			else{
-				ImageCache.add(Paths.file(Startup.characters[charI], "images", "png"));
+				ImageCache.preload(Paths.file(Startup.characters[charI], "images", "png"));
 				charI++;
 			}
 		}
@@ -115,7 +114,7 @@ class CacheReload extends FlxState
 				graphicsCached = true;
 			}
 			else{
-				ImageCache.add(Paths.file(Startup.graphics[gfxI], "images", "png"));
+				ImageCache.preload(Paths.file(Startup.graphics[gfxI], "images", "png"));
 				gfxI++;
 			}
 		}

--- a/source/debug/AnimationDebug.hx
+++ b/source/debug/AnimationDebug.hx
@@ -1,5 +1,6 @@
 package debug;
 
+import caching.ImageCache;
 import modding.PolymodHandler;
 import characters.ScriptableCharacter;
 import characters.CharacterInfoBase;
@@ -212,8 +213,8 @@ class AnimationDebug extends FlxState
 			genBoyOffsets(false);
 		}
 		
-		if (FlxG.keys.justPressed.ESCAPE)
-		{
+		if (FlxG.keys.justPressed.ESCAPE){
+			ImageCache.refreshLocal();
 			FlxG.switchState(new PlayState());
 		}
 

--- a/source/debug/ChartingState.hx
+++ b/source/debug/ChartingState.hx
@@ -1216,7 +1216,7 @@ class ChartingState extends MusicBeatState
 					
 				PlayState.loadEvents = false;
 		
-				ImageCache.keepCache = true;
+				ImageCache.skipDestroy = true;
 				switchState(new PlayState());
 			}
 		

--- a/source/debug/ChartingState.hx
+++ b/source/debug/ChartingState.hx
@@ -1215,8 +1215,6 @@ class ChartingState extends MusicBeatState
 				}
 					
 				PlayState.loadEvents = false;
-		
-				ImageCache.skipDestroy = true;
 				switchState(new PlayState());
 			}
 		

--- a/source/debug/ChartingState.hx
+++ b/source/debug/ChartingState.hx
@@ -444,7 +444,8 @@ class ChartingState extends MusicBeatState
 				events: []
 			};
 
-			FlxG.resetState();
+			ImageCache.refreshLocal();
+			switchState(new ChartingState());
 		});
 
 		var stepperSpeed:FlxUINumericStepper = new FlxUINumericStepper(10, 70, 0.1, 1, 0.1, 25, 1);
@@ -1215,6 +1216,7 @@ class ChartingState extends MusicBeatState
 				}
 					
 				PlayState.loadEvents = false;
+				ImageCache.refreshLocal();
 				switchState(new PlayState());
 			}
 		
@@ -1901,13 +1903,15 @@ class ChartingState extends MusicBeatState
 		if(PlayState.SONG.gf == null){
 			PlayState.SONG.gf = _song.gf;
 		}
-		FlxG.resetState();
+		ImageCache.refreshLocal();
+		switchState(new ChartingState());
 	}
 
 	function loadAutosave():Void{
 		PlayState.SONG = Song.parseJSONshit(FlxG.save.data.autosave);
 		PlayState.EVENTS = Song.parseEventJSON(FlxG.save.data.autosaveEvents);
-		FlxG.resetState();
+		ImageCache.refreshLocal();
+		switchState(new ChartingState());
 	}
 
 	function autosaveSong():Void{

--- a/source/freeplay/FreeplayState.hx
+++ b/source/freeplay/FreeplayState.hx
@@ -286,7 +286,7 @@ class FreeplayState extends MusicBeatState
 						exitAnimation();
 						customTransOut = new InstantTransition();
 						MainMenuState.fromFreeplay = true;
-						ImageCache.keepCache = true;
+						ImageCache.skipDestroy = true;
 						new FlxTimer().start(transitionTimeExit + (staggerTimeExit*4), function(t) {
 							switchState(new MainMenuState());
 						});
@@ -605,8 +605,6 @@ class FreeplayState extends MusicBeatState
 
 		menuItems = new FlxTypedGroup<FlxSprite>();
 		add(menuItems);
-
-		var tex = Paths.getSparrowAtlas('menu/FNF_main_menu_assets');
 
 		for (i in 0...MainMenuState.optionShit.length)
 		{

--- a/source/freeplay/FreeplayState.hx
+++ b/source/freeplay/FreeplayState.hx
@@ -1010,6 +1010,7 @@ class FreeplayState extends MusicBeatState
 		PlayState.loadEvents = true;
 		PlayState.returnLocation = "freeplay";
 		new FlxTimer().start(1.5, function(t){
+			ImageCache.forceClearOnTransition = true;
 			switchState(new PlayState());
 			FlxG.sound.music.fadeOut(0.5);
 		});

--- a/source/freeplay/FreeplayState.hx
+++ b/source/freeplay/FreeplayState.hx
@@ -286,7 +286,6 @@ class FreeplayState extends MusicBeatState
 						exitAnimation();
 						customTransOut = new InstantTransition();
 						MainMenuState.fromFreeplay = true;
-						ImageCache.skipDestroy = true;
 						new FlxTimer().start(transitionTimeExit + (staggerTimeExit*4), function(t) {
 							switchState(new MainMenuState());
 						});

--- a/source/modding/PolymodHandler.hx
+++ b/source/modding/PolymodHandler.hx
@@ -47,7 +47,8 @@ class PolymodHandler
 			dirs: loadedModDirs,
 			useScriptedClasses: true,
 			errorCallback: onPolymodError,
-			frameworkParams: buildFrameworkParams()
+			frameworkParams: buildFrameworkParams(),
+			ignoredFiles: buildIgnoreList(),
 		});
 
 		//trace("Mod Meta List: " + loadedModMetadata);
@@ -370,6 +371,17 @@ class PolymodHandler
 				"videos" => "videos"
 			]
 		}
+	}
+
+	static function buildIgnoreList():Array<String>{
+		var result = Polymod.getDefaultIgnoreList();
+
+    	result.push('.git');
+    	result.push('.gitignore');
+    	result.push('.gitattributes');
+    	result.push('README.md');
+
+    	return result;
 	}
 }
 

--- a/source/story/StoryMenuState.hx
+++ b/source/story/StoryMenuState.hx
@@ -382,6 +382,7 @@ class StoryMenuState extends MusicBeatState
 				if (FlxG.sound.music != null)
 					FlxG.sound.music.stop();
 				PlayState.loadEvents = true;
+				ImageCache.forceClearOnTransition = true;
 				switchState(new PlayState());
 			});
 		}

--- a/source/transition/BaseTransition.hx
+++ b/source/transition/BaseTransition.hx
@@ -45,8 +45,7 @@ class BaseTransition extends FlxSpriteGroup{
 			FlxG.signals.preStateCreate.addOnce(function(state){
 				ImageCache.destroyByCount();
 				AudioCache.clear();
-
-				ImageCache.skipDestroy = false; // Make sure to set this to false to avoid clutter
+				
 				Utils.gc();
 			});
 

--- a/source/transition/BaseTransition.hx
+++ b/source/transition/BaseTransition.hx
@@ -39,15 +39,14 @@ class BaseTransition extends FlxSpriteGroup{
 	**/
 	public function end(){
 		FlxUIStateExt.inTransition = false;
-		
+
 		if(state != null){ //State exit animation.
 			//FlxG.signals.postStateSwitch.addOnce(Utils.gc);
 			FlxG.signals.preStateCreate.addOnce(function(state){
-				if(!ImageCache.keepCache){
-					ImageCache.clear();
-					AudioCache.clear();
-				}
-				ImageCache.keepCache = false; // Make sure to set this to false to avoid clutter
+				ImageCache.destroyByCount();
+				AudioCache.clear();
+
+				ImageCache.skipDestroy = false; // Make sure to set this to false to avoid clutter
 				Utils.gc();
 			});
 
@@ -57,7 +56,7 @@ class BaseTransition extends FlxSpriteGroup{
 		else{ //State intro animation.
 			FlxG.signals.postUpdate.addOnce(function(){Utils.gc();});
 			FlxG.cameras.remove(cameras[0], true);
-			this.destroy();
+			Utils.destroyWhenAvailable(this);
 		}
 	}
 

--- a/source/transition/BaseTransition.hx
+++ b/source/transition/BaseTransition.hx
@@ -43,7 +43,13 @@ class BaseTransition extends FlxSpriteGroup{
 		if(state != null){ //State exit animation.
 			//FlxG.signals.postStateSwitch.addOnce(Utils.gc);
 			FlxG.signals.preStateCreate.addOnce(function(state){
-				ImageCache.destroyByCount();
+				if(!ImageCache.forceClearOnTransition){
+					ImageCache.destroyByCount();
+				}
+				else{
+					ImageCache.clearLocal();
+					ImageCache.forceClearOnTransition = false;
+				}
 				AudioCache.clear();
 				
 				Utils.gc();


### PR DESCRIPTION
### changes
- Improved performance without GPU graphics.
- Instead of deleting all graphics at once, we implemented a counter on each image asset that is decremented every time its state changes, and when it reaches 0 it is cleared from VRAM.
- Combined bitmap class used for local and preload into one
- Preloadable music is now automatically retrieved from the assets folder.
(I tried to do the same for characters and stages, but didn't implement it because I couldn't handle exceptions like Abot.)
- polymod now excludes .git~~ files on reloading