### PR TITLE
Allows add custom assets to preload

### DIFF
--- a/art/futureDocs/Home.md
+++ b/art/futureDocs/Home.md
@@ -1,0 +1,41 @@
+# FPS Plus Modding Wiki
+
+Welcome to the FPS Plus Modding Wiki. Here you will find documentation and guides on how to make a mod using FPS Plus.
+
+*This wiki is very much a work in progress.*
+
+## Getting Started
+
+To create a mod that the game will recognize and load, you have to create a folder in the `mods/` directory of FPS Plus. In that folder you *must* include a `meta.json` file with the following fields:
+
+- `uid`: A unique indentifier that you can use to identify your mod in a script.
+	- A good way to ensure that you pick a unique name is using [reverse domain name notation](https://en.wikipedia.org/wiki/Reverse_domain_name_notation), however this string can be whatever you want it to be.
+- `api_version`: A string containing the API version this mod was built for. You can find this in the bottom left corner of the main menu screen.
+- `mod_version`: The current version of your mod. This is a requirement for Polymod and can be anything.
+
+You can and should also include other information like the mod's title and a description. If you want to find out everything you can include in the `meta.json` file [check out this page in the Polymod documentation](https://polymod.io/docs/mod-metadata/). *Note that this page doesn't mention `uid` since it is not a standard Polymod feature.*
+
+You can also include an image called `icon.png`. This is an 80x80 image that will be used as the mod's icon in the mod menu in-game.
+
+## Adding Graphics to the Asset Preload
+
+FPS Plus allows you to add graphics to a preload list so that users can pre-cache graphics if they so choose. To add custom mod assets to the preload list you need to add an object in `meta.json` called `"preload"` that can contain the following fields:
+
+- `characters`: An array containing the paths of character graphics you want to preload. While you can add any image path, this should be reserved for character graphics or any graphics related to a character's objects.
+- `graphics`: An array containing the paths of any other graphics you want to preload.
+
+*Note that the paths should use the same format as if you were loading them with `Paths.image()`*.
+
+You can also use `*` as a wildcard to add every image in a folder or start a file with `!` to exclude it even though it would normally be added with a wildcard.
+
+Example:
+```json
+"preload": {
+	"characters": [
+		"customBoyfriend", "customGirlfriend", "customOpponent"
+	],
+	"graphics": [
+		"customNoteskin", "customStage/*", "!customStage/excludeMe"
+	]
+}
+```

--- a/source/Startup.hx
+++ b/source/Startup.hx
@@ -45,7 +45,7 @@ class Startup extends FlxUIStateExt
 	var charactersCached:Bool;
 	var startCachingCharacters:Bool = false;
 	var charI:Int = 0;
-	public static final characters:Array<String> =   ["BOYFRIEND", "BOYFRIEND_DEAD", "week4/bfCar", "week5/bfChristmas", "week6/bfPixel", "week6/bfPixelsDEAD", "week7/bfAndGF", "week7/bfHoldingGF-DEAD",
+	public static var characters:Array<String> =   ["BOYFRIEND", "BOYFRIEND_DEAD", "week4/bfCar", "week5/bfChristmas", "week6/bfPixel", "week6/bfPixelsDEAD", "week7/bfAndGF", "week7/bfHoldingGF-DEAD",
 									"GF_assets", "week4/gfCar", "week5/gfChristmas", "week6/gfPixel", "week7/gfTankmen",
 									"week1/DADDY_DEAREST", 
 									"week2/spooky_kids_assets", "week2/Monster_Assets",
@@ -55,24 +55,20 @@ class Startup extends FlxUIStateExt
 									"week6/senpai", "week6/spirit",
 									"week7/tankmanCaptain",
 									"weekend1/darnell",
-									"weekend1/Nene", "weekend1/abot/aBotViz", "weekend1/abot/stereoBG"];
+									"weekend1/Nene", "weekend1/abot/*", "weekend1/abot/*"];
 
 	var graphicsCached:Bool;
 	var startCachingGraphics:Bool = false;
 	var gfxI:Int = 0;
-	public static final graphics:Array<String> =	["logoBumpin", "titleEnter", "fpsPlus/title/backgroundBf", "fpsPlus/title/barBottom", "fpsPlus/title/barTop", "fpsPlus/title/gf", "fpsPlus/title/glow", 
+	public static var graphics:Array<String> = ["logoBumpin", "titleEnter", "fpsPlus/title/backgroundBf", "fpsPlus/title/barBottom", "fpsPlus/title/barTop", "fpsPlus/title/gf", "fpsPlus/title/glow", 
 									"week1/stageback", "week1/stagefront", "week1/stagecurtains",
-									"week2/stage/shadowsWhite", "week2/stage/window", "week2/stage/windowLightWhite",
-									"week3/philly/sky", "week3/philly/city", "week3/philly/behindTrain", "week3/philly/train", "week3/philly/street", "week3/philly/windowWhite", "week3/philly/windowWhiteGlow",
-									"week4/limo/bgLimo", "week4/limo/fastCarLol", "week4/limo/limoDancer", "week4/limo/limoDrive", "week4/limo/limoSunset",
-									"week5/christmas/bgWalls", "week5/christmas/upperBop", "week5/christmas/bgEscalator", "week5/christmas/christmasTree", "week5/christmas/bottomBop", "week5/christmas/fgSnow", "week5/christmas/santa",
-									"week5/christmas/evilBG", "week5/christmas/evilTree", "week5/christmas/evilSnow",
-									"week6/weeb/sky", "week6/weeb/farBackTrees", "week6/weeb/school", "week6/weeb/ground", "week6/weeb/backTrees", "week6/weeb/weebTrees", "week6/weeb/petals", "week6/weeb/bgFreaks",
-									"week6/weeb/animatedEvilSchool", "week6/weeb/senpaiCrazy",
-									"week7/stage/tank0", "week7/stage/tank1", "week7/stage/tank2", "week7/stage/tank3", "week7/stage/tank4", "week7/stage/tank5", "week7/stage/tankmanKilled1", 
-									"week7/stage/smokeLeft", "week7/stage/smokeRight", "week7/stage/tankBuildings", "week7/stage/tankClouds", "week7/stage/tankGround", "week7/stage/tankMountains", "week7/stage/tankRolling", "week7/stage/tankRuins", "week7/stage/tankSky", "week7/stage/tankWatchtower",
-									"weekend1/phillyStreets/phillyCars","weekend1/phillyStreets/phillyConstruction","weekend1/phillyStreets/phillyForeground","weekend1/phillyStreets/phillyForegroundCity","weekend1/phillyStreets/phillyHighway","weekend1/phillyStreets/phillyHighwayLights","weekend1/phillyStreets/phillyHighwayLights_lightmap","weekend1/phillyStreets/phillySkybox","weekend1/phillyStreets/phillySkyline","weekend1/phillyStreets/phillySmog","weekend1/phillyStreets/phillyTraffic","weekend1/phillyStreets/phillyTraffic_lightmap","weekend1/phillyStreets/SpraycanPile",  
-									"weekend1/phillyBlazin/lightning", "weekend1/phillyBlazin/skyBlur", "weekend1/phillyBlazin/streetBlur"];
+									"week2/stage/*",
+									"week3/philly/*",
+									"week4/limo/*",
+									"week5/christmas/*",
+									"week6/weeb/*",
+									"week7/stage/*",
+									"weekend1/phillyStreets/*", "weekend1/phillyBlazin/*"];
 
 	var cacheStart:Bool = false;
 
@@ -130,6 +126,17 @@ class Startup extends FlxUIStateExt
 		splash.animation.play("start");
 		splash.updateHitbox();
 		splash.screenCenter();
+
+		for (mod in PolymodHandler.loadedModDirs)
+		{
+			var meta = haxe.Json.parse(sys.io.File.getContent("mods/" + mod + "/meta.json"));
+			if (meta.preload != null && meta.preload.characters != null){
+				characters = characters.concat(meta.preload.characters);
+			}
+			if (meta.preload != null && meta.preload.graphics != null){
+				graphics = graphics.concat(meta.preload.graphics);
+			}
+		}
 
 		loadTotal = (!charactersCached ? characters.length : 0) + (!graphicsCached ? graphics.length : 0);
 
@@ -226,11 +233,20 @@ class Startup extends FlxUIStateExt
 				charactersCached = true;
 			}
 			else{
-				if(Utils.exists(Paths.file(characters[charI], "images", "png"))){
-					ImageCache.preload(Paths.file(characters[charI], "images", "png"));
+				if (characters[charI].endsWith("/*")){
+					for (f in Utils.listEveryFileInFolder("images/" + characters[charI].split("/*")[0], ".png")){
+						if(Utils.exists('assets/images/${ characters[charI].split("/*")[0]}/' + f)){
+							ImageCache.preload('assets/images/${ characters[charI].split("/*")[0]}/' + f);
+						}else{
+							trace("Graphic: File at " +  f + " not found, skipping cache.");
+						}
+					}
+				}
+				else if(Utils.exists(Paths.file( characters[charI], "images", "png"))){
+					ImageCache.preload(Paths.file( characters[charI], "images", "png"));
 				}
 				else{
-					trace("Character: File at " + characters[charI] + " not found, skipping cache.");
+					trace("Graphic: File at " +  characters[charI] + " not found, skipping cache.");
 				}
 				charI++;
 				currentLoaded++;
@@ -244,7 +260,16 @@ class Startup extends FlxUIStateExt
 				graphicsCached = true;
 			}
 			else{
-				if(Utils.exists(Paths.file(graphics[gfxI], "images", "png"))){
+				if (graphics[gfxI].endsWith("/*")){
+					for (f in Utils.listEveryFileInFolder("images/" + graphics[gfxI].split("/*")[0], ".png")){
+						if(Utils.exists('assets/images/${graphics[gfxI].split("/*")[0]}/' + f)){
+							ImageCache.preload('assets/images/${graphics[gfxI].split("/*")[0]}/' + f);
+						}else{
+							trace("Graphic: File at " + f + " not found, skipping cache.");
+						}
+					}
+				}
+				else if(Utils.exists(Paths.file(graphics[gfxI], "images", "png"))){
 					ImageCache.preload(Paths.file(graphics[gfxI], "images", "png"));
 				}
 				else{
@@ -294,7 +319,14 @@ class Startup extends FlxUIStateExt
 
 	function preloadCharacters(){
 		for(x in characters){
-			ImageCache.preload(Paths.file(x, "images", "png"));
+			if (x.endsWith("/*")){
+				for (f in Utils.listEveryFileInFolder("images/" + x.split("/*")[0], ".png")){
+					trace("caching from: " + 'assets/images/${x.split("/*")[0]}/' + f);
+					ImageCache.preload('assets/images/${x.split("/*")[0]}/' + f);
+				}
+			}else{
+				ImageCache.preload(Paths.file(x, "images", "png"));
+			}
 			//trace("Chached " + x);
 		}
 		loadingText.text = "Characters cached...";
@@ -303,8 +335,14 @@ class Startup extends FlxUIStateExt
 
 	function preloadGraphics(){
 		for(x in graphics){
-			ImageCache.preload(Paths.file(x, "images", "png"));
-			//trace("Chached " + x);
+			if (x.endsWith("/*")){
+				for (f in Utils.listEveryFileInFolder("images/" + x.split("/*")[0], ".png")){
+					trace("caching from: " + 'assets/images/${x.split("/*")[0]}/' + f);
+					ImageCache.preload('assets/images/${x.split("/*")[0]}/' + f);
+				}
+			}else{
+				ImageCache.preload(Paths.file(x, "images", "png"));
+			}
 		}
 		loadingText.text = "Graphics cached...";
 		graphicsCached = true;

--- a/source/Startup.hx
+++ b/source/Startup.hx
@@ -45,30 +45,10 @@ class Startup extends FlxUIStateExt
 	var charactersCached:Bool;
 	var startCachingCharacters:Bool = false;
 	var charI:Int = 0;
-	public static var characters:Array<String> =   ["BOYFRIEND", "BOYFRIEND_DEAD", "week4/bfCar", "week5/bfChristmas", "week6/bfPixel", "week6/bfPixelsDEAD", "week7/bfAndGF", "week7/bfHoldingGF-DEAD",
-									"GF_assets", "week4/gfCar", "week5/gfChristmas", "week6/gfPixel", "week7/gfTankmen",
-									"week1/DADDY_DEAREST", 
-									"week2/spooky_kids_assets", "week2/Monster_Assets",
-									"week3/Pico_FNF_assetss", "week7/picoSpeaker", "weekend1/pico_weekend1",  "weekend1/pico_death",  "weekend1/Pico_Death_Retry",  "weekend1/Pico_Intro",  "weekend1/picoBlazinDeathConfirm", 
-									"week4/Mom_Assets", "week4/momCar",
-									"week5/mom_dad_christmas_assets", "week5/monsterChristmas",
-									"week6/senpai", "week6/spirit",
-									"week7/tankmanCaptain",
-									"weekend1/darnell",
-									"weekend1/Nene", "weekend1/abot/*"];
 
 	var graphicsCached:Bool;
 	var startCachingGraphics:Bool = false;
 	var gfxI:Int = 0;
-	public static var graphics:Array<String> = ["logoBumpin", "titleEnter", "fpsPlus/title/*", 
-									"week1/stageback", "week1/stagefront", "week1/stagecurtains",
-									"week2/stage/*",
-									"week3/philly/*",
-									"week4/limo/*",
-									"week5/christmas/*",
-									"week6/weeb/*",
-									"week7/stage/*",
-									"weekend1/phillyStreets/*", "weekend1/phillyBlazin/*"];
 
 	var cacheStart:Bool = false;
 
@@ -127,18 +107,9 @@ class Startup extends FlxUIStateExt
 		splash.updateHitbox();
 		splash.screenCenter();
 
-		for (mod in PolymodHandler.loadedModDirs)
-		{
-			var meta = haxe.Json.parse(sys.io.File.getContent("mods/" + mod + "/meta.json"));
-			if (meta.preload != null && meta.preload.characters != null){
-				characters = characters.concat(meta.preload.characters);
-			}
-			if (meta.preload != null && meta.preload.graphics != null){
-				graphics = graphics.concat(meta.preload.graphics);
-			}
-		}
+		CacheReload.buildPreloadList();
 
-		loadTotal = (!charactersCached ? characters.length : 0) + (!graphicsCached ? graphics.length : 0);
+		loadTotal = (!charactersCached ? CacheReload.characterPreloadList.length : 0) + (!graphicsCached ? CacheReload.graphicsPreloadList.length : 0);
 
 		if(loadTotal > 0){
 			loadingBar = new FlxBar(0, 605, LEFT_TO_RIGHT, 600, 24, this, 'currentLoaded', 0, loadTotal);
@@ -227,54 +198,26 @@ class Startup extends FlxUIStateExt
 		}
 
 		if(startCachingCharacters){
-			if(charI >= characters.length){
+			if(charI >= CacheReload.characterPreloadList.length){
 				loadingText.text = "Characters cached...";
 				startCachingCharacters = false;
 				charactersCached = true;
 			}
 			else{
-				if (characters[charI].endsWith("/*")){
-					for (f in Utils.listEveryFileInFolder("images/" + characters[charI].split("/*")[0], ".png")){
-						if(Utils.exists('assets/images/${ characters[charI].split("/*")[0]}/' + f)){
-							ImageCache.preload('assets/images/${ characters[charI].split("/*")[0]}/' + f);
-						}else{
-							trace("Graphic: File at " +  f + " not found, skipping cache.");
-						}
-					}
-				}
-				else if(Utils.exists(Paths.file( characters[charI], "images", "png"))){
-					ImageCache.preload(Paths.file( characters[charI], "images", "png"));
-				}
-				else{
-					trace("Graphic: File at " +  characters[charI] + " not found, skipping cache.");
-				}
+				CacheReload.cacheCharacter(charI);
 				charI++;
 				currentLoaded++;
 			}
 		}
 
 		if(startCachingGraphics){
-			if(gfxI >= graphics.length){
+			if(gfxI >= CacheReload.graphicsPreloadList.length){
 				loadingText.text = "Graphics cached...";
 				startCachingGraphics = false;
 				graphicsCached = true;
 			}
 			else{
-				if (graphics[gfxI].endsWith("/*")){
-					for (f in Utils.listEveryFileInFolder("images/" + graphics[gfxI].split("/*")[0], ".png")){
-						if(Utils.exists('assets/images/${graphics[gfxI].split("/*")[0]}/' + f)){
-							ImageCache.preload('assets/images/${graphics[gfxI].split("/*")[0]}/' + f);
-						}else{
-							trace("Graphic: File at " + f + " not found, skipping cache.");
-						}
-					}
-				}
-				else if(Utils.exists(Paths.file(graphics[gfxI], "images", "png"))){
-					ImageCache.preload(Paths.file(graphics[gfxI], "images", "png"));
-				}
-				else{
-					trace("Graphic: File at " + graphics[gfxI] + " not found, skipping cache.");
-				}
+				CacheReload.cacheGraphic(gfxI);
 				gfxI++;
 				currentLoaded++;
 			}
@@ -315,37 +258,6 @@ class Startup extends FlxUIStateExt
 			startCachingGraphics = true;
 		}
 
-	}
-
-	function preloadCharacters(){
-		for(x in characters){
-			if (x.endsWith("/*")){
-				for (f in Utils.listEveryFileInFolder("images/" + x.split("/*")[0], ".png")){
-					trace("caching from: " + 'assets/images/${x.split("/*")[0]}/' + f);
-					ImageCache.preload('assets/images/${x.split("/*")[0]}/' + f);
-				}
-			}else{
-				ImageCache.preload(Paths.file(x, "images", "png"));
-			}
-			//trace("Chached " + x);
-		}
-		loadingText.text = "Characters cached...";
-		charactersCached = true;
-	}
-
-	function preloadGraphics(){
-		for(x in graphics){
-			if (x.endsWith("/*")){
-				for (f in Utils.listEveryFileInFolder("images/" + x.split("/*")[0], ".png")){
-					trace("caching from: " + 'assets/images/${x.split("/*")[0]}/' + f);
-					ImageCache.preload('assets/images/${x.split("/*")[0]}/' + f);
-				}
-			}else{
-				ImageCache.preload(Paths.file(x, "images", "png"));
-			}
-		}
-		loadingText.text = "Graphics cached...";
-		graphicsCached = true;
 	}
 
 	function openPreloadSettings(){

--- a/source/Startup.hx
+++ b/source/Startup.hx
@@ -55,12 +55,12 @@ class Startup extends FlxUIStateExt
 									"week6/senpai", "week6/spirit",
 									"week7/tankmanCaptain",
 									"weekend1/darnell",
-									"weekend1/Nene", "weekend1/abot/*", "weekend1/abot/*"];
+									"weekend1/Nene", "weekend1/abot/*"];
 
 	var graphicsCached:Bool;
 	var startCachingGraphics:Bool = false;
 	var gfxI:Int = 0;
-	public static var graphics:Array<String> = ["logoBumpin", "titleEnter", "fpsPlus/title/backgroundBf", "fpsPlus/title/barBottom", "fpsPlus/title/barTop", "fpsPlus/title/gf", "fpsPlus/title/glow", 
+	public static var graphics:Array<String> = ["logoBumpin", "titleEnter", "fpsPlus/title/*", 
 									"week1/stageback", "week1/stagefront", "week1/stagecurtains",
 									"week2/stage/*",
 									"week3/philly/*",

--- a/source/Utils.hx
+++ b/source/Utils.hx
@@ -189,6 +189,18 @@ class Utils
 		return files;
 	}
 
+	public static inline function listEveryFileInFolder(folder:String, postfix:String)
+	{
+		var last:Array<String> = [];
+		var assets = Assets.list();
+		for (file in assets){
+			if (file.startsWith('assets/$folder/') && file.endsWith(postfix)){
+				last.push(file.split('assets/$folder/')[1]);
+			}
+		}
+		return last;
+	}
+
 	//Removes duplicate items from an array. Can additionally supply extra arrays to check from.
 	public static function removeDuplicates(arr:Dynamic, ?extraArrayComparisons:Array<Dynamic>):Dynamic{
 		if(extraArrayComparisons == null){ extraArrayComparisons = []; }

--- a/source/config/CacheReload.hx
+++ b/source/config/CacheReload.hx
@@ -178,10 +178,10 @@ class CacheReload extends FlxState
 
 		for(mod in PolymodHandler.loadedModDirs){
 			var meta = haxe.Json.parse(sys.io.File.getContent("mods/" + mod + "/meta.json"));
-			if (meta.preload != null && meta.preload.characters != null){
+			if(meta.preload != null && meta.preload.characters != null){
 				characterPreloadList = characterPreloadList.concat(meta.preload.characters);
 			}
-			if (meta.preload != null && meta.preload.graphics != null){
+			if(meta.preload != null && meta.preload.graphics != null){
 				graphicsPreloadList = graphicsPreloadList.concat(meta.preload.graphics);
 			}
 		}
@@ -194,9 +194,9 @@ class CacheReload extends FlxState
 		var finalArray:Array<String> = [];
 		var excludes:Array<String> = [];
 
-		for (file in list){
-			if (file.endsWith("/*")){
-				if (file.startsWith("!")){
+		for(file in list){
+			if(file.endsWith("/*")){
+				if(file.startsWith("!")){
 					var thing = file.split("!")[1];
 					for(f in Utils.listEveryFileInFolder("images/" + thing.split("/*")[0], ".png")){
 						excludes.push(thing.split("/*")[0] + "/" + f.split(".png")[0]);
@@ -209,18 +209,18 @@ class CacheReload extends FlxState
 				}
 			}
 			else{
-				if (file.startsWith("!")){
+				if(file.startsWith("!")){
 					excludes.push(file);
-				}else{
+				}
+				else{
 					finalArray.push(file);
 				}
 			}	
 		}
 
-		for (fil in finalArray){
-			if (excludes.contains(fil)){
-				// trace("excluded file " + fil);
-				finalArray.remove(fil);
+		for(file in finalArray){
+			if(excludes.contains(file)){
+				finalArray.remove(file);
 			}
 		}
 

--- a/source/modding/ModManagerState.hx
+++ b/source/modding/ModManagerState.hx
@@ -321,6 +321,7 @@ class ModManagerState extends FlxUIStateExt
 					}
 			
 					if(Binds.justPressed("menuBack")){
+						ImageCache.forceClearOnTransition = true;
 						FlxG.sound.play(Paths.sound("cancelMenu"));
 						canDoThings = false;
 						save();


### PR DESCRIPTION
Added preload field to metadata to allow mods to load their own assets on startup.
<img width="200" alt="スクリーンショット 2025-06-03 12 20 03" src="https://github.com/user-attachments/assets/3f1af471-74b9-4718-9646-8276bb5e00ec" />

also added a feature that allows you to get all images in a folder if path ends with "/*".