### PR TITLE
add REDIRECT_ASSETS_FOLDER/coreAssetRedirect

### DIFF
--- a/Project.xml
+++ b/Project.xml
@@ -38,7 +38,14 @@
 
 	<classpath name="source" />
 
-	<assets path="assets" >
+	<assets path="assets/images" />
+	<assets path="assets/data" />
+	<assets path="assets/videos" />
+
+	<assets path="assets/music" include="*.ogg" />
+	<assets path="assets/sounds" include="*.ogg" />
+	<assets path="assets/songs" />
+
 	<assets path="mods" />
 
 	<!-- Didn't delete it just because some mods could use it -->

--- a/Project.xml
+++ b/Project.xml
@@ -38,14 +38,7 @@
 
 	<classpath name="source" />
 
-	<assets path="assets/images" />
-	<assets path="assets/data" />
-	<assets path="assets/videos" />
-
-	<assets path="assets/music" include="*.ogg" />
-	<assets path="assets/sounds" include="*.ogg" />
-	<assets path="assets/songs" />
-
+	<assets path="assets" >
 	<assets path="mods" />
 
 	<!-- Didn't delete it just because some mods could use it -->

--- a/source/Utils.hx
+++ b/source/Utils.hx
@@ -173,11 +173,12 @@ class Utils
 
 	//FileSystem readDirectory but with mods folder
 	public static inline function readDirectory(path:String):Array<String>{
-		var files:Array<String> = null;
-		if(FileSystem.exists(path)){ files = FileSystem.readDirectory(path); }
+		var files:Array<String> = [];
+		path = path.replace("assets/", PolymodHandler.ASSETS_FOLDER + "/");
+
+		if(FileSystem.exists(path)){files = FileSystem.readDirectory(path);}
 		for (mod in PolymodHandler.loadedModDirs){
 			if (FileSystem.exists('mods/$mod/' + path.split("assets/")[1])){
-				if(files == null){ files = []; }
 				var modfile = FileSystem.readDirectory('mods/$mod/' + path.split("assets/")[1]);
 				for (file in modfile){
 					if (!files.contains(file)){

--- a/source/modding/PolymodHandler.hx
+++ b/source/modding/PolymodHandler.hx
@@ -15,6 +15,15 @@ class PolymodHandler
 
 	public static final API_VERSION:Array<Int> = [1, 6, 0];
 	public static final API_VERSION_STRING:String = API_VERSION[0]+"."+API_VERSION[1]+"."+API_VERSION[2];
+
+	public static final ASSETS_FOLDER:String =
+    #if (REDIRECT_ASSETS_FOLDER && macos)
+    "../../../../../../../assets"
+    #elseif REDIRECT_ASSETS_FOLDER
+    "../../../../assets"
+    #else
+    "assets"
+    #end;
 	
 	public static var allModDirs:Array<String>;
 	public static var disabledModDirs:Array<String>;
@@ -48,6 +57,9 @@ class PolymodHandler
 			useScriptedClasses: true,
 			errorCallback: onPolymodError,
 			ignoredFiles: buildIgnoreList(),
+			frameworkParams: {
+				coreAssetRedirect: ASSETS_FOLDER
+			}
 		});
 
 		//trace("Mod Meta List: " + loadedModMetadata);


### PR DESCRIPTION
fixes #176
Added REDIRECT_ASSETS_FOLDER compile flag that make game load scripts and assets from the source folder.
also set Polymod's coreAssetRedirect for allowing add scripts to assets on compiled build.