### PR TITLE
make more objects scriptable

### DIFF
--- a/Project.xml
+++ b/Project.xml
@@ -13,6 +13,7 @@
 	<compilerflag name="--macro" value="include('shaders', true)" />
 	<compilerflag name="--macro" value="include('objects', true)" />
 	<compilerflag name="--macro" value="include('ui', true)" />
+	<compilerflag name="--macro" value="include('transition', true)" />
 
 	<!--Allows all of Flixel to be used by scripts at runtime instead of only what was imported in the code.-->
 	<compilerflag name="--macro" value="include('flixel', true, [ 'flixel.addons.editors.spine.*', 'flixel.addons.nape.*', 'flixel.system.macros.*' ])" />

--- a/source/Main.hx
+++ b/source/Main.hx
@@ -8,12 +8,12 @@ import flixel.FlxG;
 import flixel.FlxGame;
 import openfl.display.Sprite;
 import debug.*;
-import openfl.display.FPS;
+import openfl.display.InteractiveObject;
 
 class Main extends Sprite
 {
 
-	public static var fpsDisplay:FPSExt;
+	public static var fpsDisplay:InteractiveObject;
 
 	public static var novid:Bool = false;
 	public static var flippymode:Bool = false;

--- a/source/modding/PolymodHandler.hx
+++ b/source/modding/PolymodHandler.hx
@@ -297,8 +297,9 @@ class PolymodHandler
 		
 		Polymod.addDefaultImport(flixel.system.FlxAssets.FlxShader);
 
+		Polymod.addDefaultImport(openfl.display.Sprite);
+
 		Polymod.addDefaultImport(transition.BaseTransition);
-		Polymod.addDefaultImport(transition.ScriptableTransition); // basically custom transitions can't do anything without this so
 		
 		//Alias
 		Polymod.addImportAlias("Binds", modding.ScriptingUtil.ScriptBinds);

--- a/source/modding/PolymodHandler.hx
+++ b/source/modding/PolymodHandler.hx
@@ -296,6 +296,9 @@ class PolymodHandler
 		Polymod.addDefaultImport(flixel.group.FlxSpriteGroup);
 		
 		Polymod.addDefaultImport(flixel.system.FlxAssets.FlxShader);
+
+		Polymod.addDefaultImport(transition.BaseTransition);
+		Polymod.addDefaultImport(transition.ScriptableTransition); // basically custom transitions can't do anything without this so
 		
 		//Alias
 		Polymod.addImportAlias("Binds", modding.ScriptingUtil.ScriptBinds);

--- a/source/objects/ScriptableOpenFLSprite.hx
+++ b/source/objects/ScriptableOpenFLSprite.hx
@@ -1,0 +1,4 @@
+package objects;
+
+@:hscriptClass
+class ScriptableOpenFLSprite extends openfl.display.Sprite implements polymod.hscript.HScriptedClass{}

--- a/source/transition/ScriptableTransition.hx
+++ b/source/transition/ScriptableTransition.hx
@@ -1,0 +1,4 @@
+package transition;
+
+@:hscriptClass
+class ScriptableTransition extends BaseTransition implements polymod.hscript.HScriptedClass{}


### PR DESCRIPTION
```transition.BaseTransition```
- for custom transitions

```openfl.display.Sprite```
- Can be used to create custom debug overlays, replace the FPS counter, etc. (also type for ```fpsCounter``` in ```Main``` has been changed to InteractiveObject)