### PR TITLE
Fix PauseSubState mentions leading to compile errors

### DIFF
--- a/source/PauseSubState.hx
+++ b/source/PauseSubState.hx
@@ -15,7 +15,7 @@ import flixel.group.FlxGroup.FlxTypedGroup;
 import flixel.sound.FlxSound;
 import flixel.util.FlxColor;
 
-class PauseSubstate extends MusicBeatSubstate
+class PauseSubState extends MusicBeatSubstate
 {
 	var grpMenuShit:FlxTypedGroup<Alphabet>;
 

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -1611,7 +1611,7 @@ class PlayState extends MusicBeatState
 
 		if (Binds.justPressed("pause") && startedCountdown && canPause){
 			paused = true;
-			openSubState(new PauseSubstate());
+			openSubState(new PauseSubState());
 		}
 
 		if (Binds.justPressed("chartEditor") && !isStoryMode){

--- a/source/modding/PolymodHandler.hx
+++ b/source/modding/PolymodHandler.hx
@@ -273,7 +273,7 @@ class PolymodHandler
 		Polymod.addDefaultImport(MusicBeatState);
 		Polymod.addDefaultImport(MusicBeatSubstate);
 		Polymod.addDefaultImport(Paths);
-		Polymod.addDefaultImport(PauseSubstate);
+		Polymod.addDefaultImport(PauseSubState);
 		Polymod.addDefaultImport(PlayState);
 		Polymod.addDefaultImport(Scoring);
 		Polymod.addDefaultImport(Utils);


### PR DESCRIPTION
For some reason a single letter in the mentions of `PauseSubState` didn't let the game compile at all, so this fixes that!