### PR TITLE
hxvlc supports more than mp4

### DIFF
--- a/source/Main.hx
+++ b/source/Main.hx
@@ -23,6 +23,7 @@ class Main extends Sprite
 		super();
 
 		PolymodHandler.init();
+		hxvlc.util.Handle.init([]); // initializes LibVLC
 		FlxSprite.defaultAntialiasing = true;
 
 		#if !debug

--- a/source/Paths.hx
+++ b/source/Paths.hx
@@ -104,8 +104,8 @@ class Paths
 		return parentFrames;
 	}
 
-	inline static public function video(key:String){
-		return file(key, "videos", "mp4");
+	inline static public function video(key:String, ?extension:String= "mp4"){
+		return file(key, "videos", extension);
 	}
 	
 	inline static public function font(key:String, ?extension:String = "ttf"){


### PR DESCRIPTION
added an extension which adds more video format support

for example: "webm", "mov", etc...
webm is mostly used for optimized videos (no you don't need a seperate audio file)

i also added [Handle.init](https://majigsaw77.github.io/hxvlc/hxvlc/util/Handle.html) so it can init libvlc faster, good for loading videos in a shorter time