### PR TITLE
Rework how CharacterInfo is loaded

### DIFF
--- a/assets/data/characters/Bf.hxc
+++ b/assets/data/characters/Bf.hxc
@@ -1,3 +1,5 @@
+package characters;
+
 class Bf extends CharacterInfoBase
 {
 

--- a/assets/data/characters/BfCar.hxc
+++ b/assets/data/characters/BfCar.hxc
@@ -1,3 +1,5 @@
+package characters;
+
 class BfCar extends CharacterInfoBase
 {
 

--- a/assets/data/characters/BfDark.hxc
+++ b/assets/data/characters/BfDark.hxc
@@ -1,3 +1,5 @@
+package characters;
+
 import shaders.TextureMixShader;
 
 class BfDark extends CharacterInfoBase

--- a/assets/data/characters/BfDead.hxc
+++ b/assets/data/characters/BfDead.hxc
@@ -1,3 +1,5 @@
+package characters;
+
 class BfDead extends CharacterInfoBase
 {
 
@@ -6,7 +8,7 @@ class BfDead extends CharacterInfoBase
 
 		includeInCharacterList = false;
 
-		info.name = "bf";
+		info.name = "bf-dead";
 		info.spritePath = "shared/boyfriend_dead";
 		info.frameLoadType = setAtlas();
 		

--- a/assets/data/characters/BfHoldingGf.hxc
+++ b/assets/data/characters/BfHoldingGf.hxc
@@ -1,3 +1,5 @@
+package characters;
+
 class BfHoldingGf extends CharacterInfoBase
 {
 

--- a/assets/data/characters/BfHoldingGfDead.hxc
+++ b/assets/data/characters/BfHoldingGfDead.hxc
@@ -1,3 +1,5 @@
+package characters;
+
 class BfHoldingGfDead extends CharacterInfoBase
 {
 

--- a/assets/data/characters/BfLil.hxc
+++ b/assets/data/characters/BfLil.hxc
@@ -1,3 +1,5 @@
+package characters;
+
 class BfLil extends CharacterInfoBase
 {
 

--- a/assets/data/characters/BfLilErect.hxc
+++ b/assets/data/characters/BfLilErect.hxc
@@ -1,3 +1,5 @@
+package characters;
+
 class BfLilErect extends CharacterInfoBase
 {
 

--- a/assets/data/characters/BfPixel.hxc
+++ b/assets/data/characters/BfPixel.hxc
@@ -1,3 +1,5 @@
+package characters;
+
 class BfPixel extends CharacterInfoBase
 {
 

--- a/assets/data/characters/BfPixelDead.hxc
+++ b/assets/data/characters/BfPixelDead.hxc
@@ -1,3 +1,5 @@
+package characters;
+
 class BfPixelDead extends CharacterInfoBase
 {
 

--- a/assets/data/characters/Dad.hxc
+++ b/assets/data/characters/Dad.hxc
@@ -1,3 +1,5 @@
+package characters;
+
 class Dad extends CharacterInfoBase
 {
 

--- a/assets/data/characters/Darnell.hxc
+++ b/assets/data/characters/Darnell.hxc
@@ -1,3 +1,5 @@
+package characters;
+
 class Darnell extends CharacterInfoBase
 {
 

--- a/assets/data/characters/DarnellBlazin.hxc
+++ b/assets/data/characters/DarnellBlazin.hxc
@@ -1,3 +1,5 @@
+package characters;
+
 class DarnellBlazin extends CharacterInfoBase
 {
 

--- a/assets/data/characters/Gf.hxc
+++ b/assets/data/characters/Gf.hxc
@@ -1,3 +1,5 @@
+package characters;
+
 import flixel.tweens.FlxEase;
 
 class Gf extends CharacterInfoBase

--- a/assets/data/characters/GfCar.hxc
+++ b/assets/data/characters/GfCar.hxc
@@ -1,3 +1,5 @@
+package characters;
+
 class GfCar extends CharacterInfoBase
 {
 

--- a/assets/data/characters/GfChristmas.hxc
+++ b/assets/data/characters/GfChristmas.hxc
@@ -1,3 +1,5 @@
+package characters;
+
 class GfChristmas extends CharacterInfoBase
 {
 

--- a/assets/data/characters/GfDark.hxc
+++ b/assets/data/characters/GfDark.hxc
@@ -1,3 +1,5 @@
+package characters;
+
 import shaders.TextureMixShader;
 
 class GfDark extends CharacterInfoBase

--- a/assets/data/characters/GfPixel.hxc
+++ b/assets/data/characters/GfPixel.hxc
@@ -1,3 +1,5 @@
+package characters;
+
 class GfPixel extends CharacterInfoBase
 {
 

--- a/assets/data/characters/GfTankmen.hxc
+++ b/assets/data/characters/GfTankmen.hxc
@@ -1,3 +1,5 @@
+package characters;
+
 class GfTankmen extends CharacterInfoBase
 {
 

--- a/assets/data/characters/GuyLil.hxc
+++ b/assets/data/characters/GuyLil.hxc
@@ -1,3 +1,5 @@
+package characters;
+
 class GuyLil extends CharacterInfoBase
 {
 

--- a/assets/data/characters/GuyLilErect.hxc
+++ b/assets/data/characters/GuyLilErect.hxc
@@ -1,3 +1,5 @@
+package characters;
+
 class GuyLilErect extends CharacterInfoBase
 {
 

--- a/assets/data/characters/Mom.hxc
+++ b/assets/data/characters/Mom.hxc
@@ -1,3 +1,5 @@
+package characters;
+
 class Mom extends CharacterInfoBase
 {
 

--- a/assets/data/characters/MomCar.hxc
+++ b/assets/data/characters/MomCar.hxc
@@ -1,3 +1,5 @@
+package characters;
+
 class MomCar extends CharacterInfoBase
 {
 

--- a/assets/data/characters/Monster.hxc
+++ b/assets/data/characters/Monster.hxc
@@ -1,3 +1,5 @@
+package characters;
+
 class Monster extends CharacterInfoBase
 {
 

--- a/assets/data/characters/MonsterChristmas.hxc
+++ b/assets/data/characters/MonsterChristmas.hxc
@@ -1,3 +1,5 @@
+package characters;
+
 class MonsterChristmas extends CharacterInfoBase
 {
 

--- a/assets/data/characters/Nene.hxc
+++ b/assets/data/characters/Nene.hxc
@@ -1,3 +1,5 @@
+package characters;
+
 import objects.ABot;
 import flixel.FlxG;
 

--- a/assets/data/characters/NeneChristmas.hxc
+++ b/assets/data/characters/NeneChristmas.hxc
@@ -1,3 +1,5 @@
+package characters;
+
 import objects.ABot;
 import flixel.FlxG;
 
@@ -10,7 +12,7 @@ class NeneChristmas extends CharacterInfoBase
 		includeInCharacterList = false;
 		includeInGfList = true;
 
-		info.name = "nene";
+		info.name = "nene-christmas";
 		info.spritePath = "week5/neneChristmas";
 		info.frameLoadType = setSparrow();
 		

--- a/assets/data/characters/NeneDark.hxc
+++ b/assets/data/characters/NeneDark.hxc
@@ -1,3 +1,5 @@
+package characters;
+
 import shaders.TextureMixShader;
 import objects.ABot;
 import flixel.FlxG;
@@ -11,7 +13,7 @@ class NeneDark extends CharacterInfoBase
 		includeInCharacterList = false;
 		includeInGfList = true;
 
-		info.name = "nene";
+		info.name = "nene-dark";
 		info.spritePath = "week2/nene_dark";
 		info.frameLoadType = setSparrow();
 		

--- a/assets/data/characters/NeneNoSpeaker.hxc
+++ b/assets/data/characters/NeneNoSpeaker.hxc
@@ -1,3 +1,5 @@
+package characters;
+
 import objects.ABot;
 import flixel.FlxG;
 
@@ -10,7 +12,7 @@ class NeneNoSpeaker extends CharacterInfoBase
 		includeInCharacterList = false;
 		includeInGfList = false;
 
-		info.name = "nene";
+		info.name = "nene-no-speaker";
 		info.spritePath = "shared/Nene";
 		info.frameLoadType = setSparrow();
 		

--- a/assets/data/characters/NenePixel.hxc
+++ b/assets/data/characters/NenePixel.hxc
@@ -1,3 +1,5 @@
+package characters;
+
 import objects.ABotPixel;
 import flixel.FlxG;
 

--- a/assets/data/characters/NeneTankmen.hxc
+++ b/assets/data/characters/NeneTankmen.hxc
@@ -1,3 +1,5 @@
+package characters;
+
 import objects.ABot;
 import flixel.FlxG;
 import flixel.FlxSprite;

--- a/assets/data/characters/OtisSpeaker.hxc
+++ b/assets/data/characters/OtisSpeaker.hxc
@@ -1,3 +1,5 @@
+package characters;
+
 import flixel.FlxG;
 import flixel.FlxSprite;
 import objects.ABot;

--- a/assets/data/characters/ParentsChristmas.hxc
+++ b/assets/data/characters/ParentsChristmas.hxc
@@ -1,3 +1,5 @@
+package characters;
+
 class ParentsChristmas extends CharacterInfoBase
 {
 

--- a/assets/data/characters/Pico.hxc
+++ b/assets/data/characters/Pico.hxc
@@ -1,3 +1,5 @@
+package characters;
+
 class Pico extends CharacterInfoBase
 {
 

--- a/assets/data/characters/PicoBlazin.hxc
+++ b/assets/data/characters/PicoBlazin.hxc
@@ -1,3 +1,5 @@
+package characters;
+
 class PicoBlazin extends CharacterInfoBase
 {
 

--- a/assets/data/characters/PicoChristmas.hxc
+++ b/assets/data/characters/PicoChristmas.hxc
@@ -1,3 +1,5 @@
+package characters;
+
 class PicoChristmas extends CharacterInfoBase
 {
 

--- a/assets/data/characters/PicoChristmasDead.hxc
+++ b/assets/data/characters/PicoChristmasDead.hxc
@@ -1,3 +1,5 @@
+package characters;
+
 import flixel.FlxSprite;
 import flixel.FlxG;
 

--- a/assets/data/characters/PicoCutscene.hxc
+++ b/assets/data/characters/PicoCutscene.hxc
@@ -1,3 +1,5 @@
+package characters;
+
 class PicoCutscene extends CharacterInfoBase
 {
 

--- a/assets/data/characters/PicoDark.hxc
+++ b/assets/data/characters/PicoDark.hxc
@@ -1,3 +1,5 @@
+package characters;
+
 import shaders.TextureMixShader;
 
 class PicoDark extends CharacterInfoBase
@@ -6,7 +8,7 @@ class PicoDark extends CharacterInfoBase
 	public function new(){
 		super();
 
-		info.name = "pico";
+		info.name = "pico-dark";
 		info.spritePath = "week2/pico_dark";
 		info.frameLoadType = setAtlas();
 		

--- a/assets/data/characters/PicoDead.hxc
+++ b/assets/data/characters/PicoDead.hxc
@@ -1,3 +1,5 @@
+package characters;
+
 import flixel.FlxSprite;
 
 class PicoDead extends CharacterInfoBase

--- a/assets/data/characters/PicoDeadExplode.hxc
+++ b/assets/data/characters/PicoDeadExplode.hxc
@@ -1,3 +1,5 @@
+package characters;
+
 class PicoDeadExplode extends CharacterInfoBase
 {
 

--- a/assets/data/characters/PicoHoldingNene.hxc
+++ b/assets/data/characters/PicoHoldingNene.hxc
@@ -1,3 +1,5 @@
+package characters;
+
 class PicoHoldingNene extends CharacterInfoBase
 {
 

--- a/assets/data/characters/PicoHoldingNeneDead.hxc
+++ b/assets/data/characters/PicoHoldingNeneDead.hxc
@@ -1,3 +1,5 @@
+package characters;
+
 class PicoHoldingNeneDead extends CharacterInfoBase
 {
 

--- a/assets/data/characters/PicoLil.hxc
+++ b/assets/data/characters/PicoLil.hxc
@@ -1,3 +1,5 @@
+package characters;
+
 class PicoLil extends CharacterInfoBase
 {
 

--- a/assets/data/characters/PicoPixel.hxc
+++ b/assets/data/characters/PicoPixel.hxc
@@ -1,3 +1,5 @@
+package characters;
+
 import flixel.FlxSprite;
 
 class PicoPixel extends CharacterInfoBase

--- a/assets/data/characters/PicoPlayer.hxc
+++ b/assets/data/characters/PicoPlayer.hxc
@@ -1,4 +1,6 @@
 //Character is here for backwards compatibility but hidden from the character list. Just use Pico instead as they now share all their assets.
+package characters;
+
 class PicoPlayer extends CharacterInfoBase
 {
 
@@ -8,7 +10,7 @@ class PicoPlayer extends CharacterInfoBase
 		includeInCharacterList = false;
 		includeInGfList = false;
 
-		info.name = "pico";
+		info.name = "pico-player";
 		info.spritePath = "shared/pico";
 		info.frameLoadType = setAtlas();
 		

--- a/assets/data/characters/PicoSpeaker.hxc
+++ b/assets/data/characters/PicoSpeaker.hxc
@@ -1,3 +1,5 @@
+package characters;
+
 import flixel.FlxG;
 
 class PicoSpeaker extends CharacterInfoBase

--- a/assets/data/characters/PicoWeekend.hxc
+++ b/assets/data/characters/PicoWeekend.hxc
@@ -1,10 +1,12 @@
+package characters;
+
 class PicoWeekend extends CharacterInfoBase
 {
 
 	public function new(){
 		super();
 
-		info.name = "pico";
+		info.name = "pico-weekend";
 		info.spritePath = "weekend1/pico_weekend";
 		info.frameLoadType = setAtlas();
 		

--- a/assets/data/characters/PicoWeekendDead.hxc
+++ b/assets/data/characters/PicoWeekendDead.hxc
@@ -1,3 +1,5 @@
+package characters;
+
 import flixel.FlxSprite;
 
 class PicoWeekendDead extends CharacterInfoBase
@@ -8,7 +10,7 @@ class PicoWeekendDead extends CharacterInfoBase
 
 		includeInCharacterList = false;
 
-		info.name = "pico-dead";
+		info.name = "pico-weekend-dead";
 		info.spritePath = "shared/pico_dead";
 		info.frameLoadType = setAtlas();
 		

--- a/assets/data/characters/Senpai.hxc
+++ b/assets/data/characters/Senpai.hxc
@@ -1,3 +1,5 @@
+package characters;
+
 class Senpai extends CharacterInfoBase
 {
 

--- a/assets/data/characters/SenpaiAngry.hxc
+++ b/assets/data/characters/SenpaiAngry.hxc
@@ -1,3 +1,5 @@
+package characters;
+
 class SenpaiAngry extends CharacterInfoBase
 {
 

--- a/assets/data/characters/Spirit.hxc
+++ b/assets/data/characters/Spirit.hxc
@@ -1,3 +1,5 @@
+package characters;
+
 import objects.DeltaTrail;
 
 class Spirit extends CharacterInfoBase

--- a/assets/data/characters/Spooky.hxc
+++ b/assets/data/characters/Spooky.hxc
@@ -1,3 +1,5 @@
+package characters;
+
 class Spooky extends CharacterInfoBase
 {
 

--- a/assets/data/characters/SpookyDark.hxc
+++ b/assets/data/characters/SpookyDark.hxc
@@ -1,3 +1,5 @@
+package characters;
+
 class SpookyDark extends CharacterInfoBase
 {
 

--- a/assets/data/characters/Tankman.hxc
+++ b/assets/data/characters/Tankman.hxc
@@ -1,3 +1,5 @@
+package characters;
+
 class Tankman extends CharacterInfoBase
 {
 

--- a/assets/data/characters/TankmanBloody.hxc
+++ b/assets/data/characters/TankmanBloody.hxc
@@ -1,10 +1,12 @@
+package characters;
+
 class TankmanBloody extends CharacterInfoBase
 {
 
 	public function new(){
 		super();
 
-		info.name = "tankman";
+		info.name = "tankman-bloody";
 		info.spritePaths = ["week7/tankmanCaptain", "week7/tankmanCaptainBloody"];
 		info.frameLoadType = setMultiSparrow();
 		

--- a/assets/data/events/CharacterAnimationEvents.hxc
+++ b/assets/data/events/CharacterAnimationEvents.hxc
@@ -120,7 +120,7 @@ class CharacterAnimationEvents extends Events
 	function changeCharacter(tag:String):Void{
 		var args = Events.getArgs(tag, ["bf", "Bf", "true"]);
 
-		if(!ScriptableCharacter.listScriptClasses().contains(args[1])){
+		if(!Character.characterInfos.exists(args[1])){
 			trace("Invalid character: " + args[1]);
 			return;
 		}

--- a/source/Character.hx
+++ b/source/Character.hx
@@ -27,9 +27,6 @@ class Character extends FlxSpriteGroup
 	public static final SHORT_SING_TOLERENCE:Float = 20;	//Millisecond tolerence for PREVENT_SHORT_SING detection.
 
 	public static var characterInfos:Map<String, CharacterInfoBase>;
-	#if BACKWARD_COMPATIBILITY
-	static var hideInfos:Array<String>;
-	#end
 
 	public var animOffsets:Map<String, Array<Dynamic>>;
 	private var originalAnimOffsets:Map<String, Array<Dynamic>>;
@@ -94,26 +91,18 @@ class Character extends FlxSpriteGroup
 
 	public static function initCharacters():Void{
 		characterInfos = new Map<String, CharacterInfoBase>();
-		hideInfos = [];
 		
 		for(scriptName in ScriptableCharacter.listScriptClasses()){
 			var info:CharacterInfoBase = ScriptableCharacter.scriptInit(scriptName);
-			trace([scriptName, info.info.name]);
-			characterInfos.set(info.info.name, info);
-			#if BACKWARD_COMPATIBILITY
 			var className = scriptName.split(".")[scriptName.split(".").length - 1];
 			characterInfos.set(className, info);
-			hideInfos.push(className);
-			#end
 		}
 	}
 
 	public static function listCharacters():Array<String>{
 		var result:Array<String> = [];
 		for (name => info in characterInfos){
-			if (!hideInfos.contains(name)){
-				result.push(name);
-			}
+			result.push(name);
 		}
 
 		return result;

--- a/source/Character.hx
+++ b/source/Character.hx
@@ -28,7 +28,7 @@ class Character extends FlxSpriteGroup
 
 	public static var characterInfos:Map<String, CharacterInfoBase>;
 	#if BACKWARD_COMPATIBILITY
-	static var hideInfos:Array<String>;
+	static var infoRedirects:Map<String, String>;
 	#end
 
 	public var animOffsets:Map<String, Array<Dynamic>>;
@@ -94,16 +94,14 @@ class Character extends FlxSpriteGroup
 
 	public static function initCharacters():Void{
 		characterInfos = new Map<String, CharacterInfoBase>();
-		hideInfos = [];
+		infoRedirects = new Map<String, String>();
 		
 		for(scriptName in ScriptableCharacter.listScriptClasses()){
 			var info:CharacterInfoBase = ScriptableCharacter.scriptInit(scriptName);
-			trace([scriptName, info.info.name]);
 			characterInfos.set(info.info.name, info);
 			#if BACKWARD_COMPATIBILITY
 			var className = scriptName.split(".")[scriptName.split(".").length - 1];
-			characterInfos.set(className, info);
-			hideInfos.push(className);
+			infoRedirects.set(className, info.info.name);
 			#end
 		}
 	}
@@ -111,9 +109,7 @@ class Character extends FlxSpriteGroup
 	public static function listCharacters():Array<String>{
 		var result:Array<String> = [];
 		for (name => info in characterInfos){
-			if (!hideInfos.contains(name)){
-				result.push(name);
-			}
+			result.push(name);
 		}
 
 		return result;
@@ -122,7 +118,12 @@ class Character extends FlxSpriteGroup
 	public static function getCharacterInfo(character:String):CharacterInfoBase
 	{
 		if (!characterInfos.exists(character)){
-			character = "bf";
+			if (infoRedirects.exists(character)){
+				character = infoRedirects.get(character);
+			}
+			else{
+				character = "bf";
+			}
 		}
 
 		return characterInfos.get(character);

--- a/source/Character.hx
+++ b/source/Character.hx
@@ -92,15 +92,10 @@ class Character extends FlxSpriteGroup
 
 	public static function initCharacters():Void{
 		characterInfos = new Map<String, CharacterInfoBase>();
-		infoRedirects = new Map<String, String>();
 		
 		for(scriptName in ScriptableCharacter.listScriptClasses()){
-			var info:CharacterInfoBase = ScriptableCharacter.scriptInit(scriptName);
-			characterInfos.set(info.info.name, info);
-			#if BACKWARD_COMPATIBILITY
 			var className = scriptName.split(".")[scriptName.split(".").length - 1];
-			infoRedirects.set(className, info.info.name);
-			#end
+			characterInfos.set(className, ScriptableCharacter.scriptInit(scriptName));
 		}
 	}
 
@@ -116,12 +111,7 @@ class Character extends FlxSpriteGroup
 	public static function getCharacterInfo(character:String):CharacterInfoBase
 	{
 		if (!characterInfos.exists(character)){
-			if (infoRedirects.exists(character)){
-				character = infoRedirects.get(character);
-			}
-			else{
-				character = "bf";
-			}
+			character = "bf";
 		}
 
 		return characterInfos.get(character);

--- a/source/Character.hx
+++ b/source/Character.hx
@@ -27,9 +27,7 @@ class Character extends FlxSpriteGroup
 	public static final SHORT_SING_TOLERENCE:Float = 20;	//Millisecond tolerence for PREVENT_SHORT_SING detection.
 
 	public static var characterInfos:Map<String, CharacterInfoBase>;
-	#if BACKWARD_COMPATIBILITY
 	static var infoRedirects:Map<String, String>;
-	#end
 
 	public var animOffsets:Map<String, Array<Dynamic>>;
 	private var originalAnimOffsets:Map<String, Array<Dynamic>>;

--- a/source/Character.hx
+++ b/source/Character.hx
@@ -5,7 +5,7 @@ import flixel.system.FlxAssets.FlxShader;
 import flixel.util.FlxSignal;
 import flixel.group.FlxSpriteGroup;
 import flixel.math.FlxPoint;
-import characters.CharacterInfoBase;
+import characters.*;
 import flixel.util.FlxColor;
 import flixel.FlxG;
 import flixel.FlxSprite;
@@ -25,6 +25,11 @@ class Character extends FlxSpriteGroup
 	public static final PREVENT_SHORT_IDLE:Bool = true;		//Prevents characters from quickly playing a few frames of their idles inbetween hitting notes. Default is true for FPS Plus, false for base game.
 	public static final PREVENT_SHORT_SING:Bool = true;		//Prevents characters from quickly playing a few frames of their sing animation when hitting multiple notes. Default is true for FPS Plus, false for base game.
 	public static final SHORT_SING_TOLERENCE:Float = 20;	//Millisecond tolerence for PREVENT_SHORT_SING detection.
+
+	public static var characterInfos:Map<String, CharacterInfoBase>;
+	#if BACKWARD_COMPATIBILITY
+	static var hideInfos:Array<String>;
+	#end
 
 	public var animOffsets:Map<String, Array<Dynamic>>;
 	private var originalAnimOffsets:Map<String, Array<Dynamic>>;
@@ -63,7 +68,7 @@ class Character extends FlxSpriteGroup
 	public var deathOffset:FlxPoint;
 	public var deathDelay:Float = 0.5;
 
-	public var worldPopupOffset:FlxPoint = new FlxPoint();
+	public var worldPopupOffset:FlxPoint = FlxPoint.get();
 
 	public var isAtlas(get, never):Bool;
 	public var isFacingDefaultDirection(get, never):Bool;
@@ -72,7 +77,7 @@ class Character extends FlxSpriteGroup
 	var atlasCharacter:AtlasSprite;
 	public var characterInfo:CharacterInfoBase;
 
-	var curOffset = new FlxPoint();
+	var curOffset = FlxPoint.get();
 
 	//var added:Bool = false;
 
@@ -86,6 +91,42 @@ class Character extends FlxSpriteGroup
 
 	public var onAnimationFrame:FlxTypedSignal<(String, Int, Int) -> Void> = new FlxTypedSignal();
 	public var onAnimationFinish:FlxTypedSignal<(String) -> Void> = new FlxTypedSignal();
+
+	public static function initCharacters():Void{
+		characterInfos = new Map<String, CharacterInfoBase>();
+		hideInfos = [];
+		
+		for(scriptName in ScriptableCharacter.listScriptClasses()){
+			var info:CharacterInfoBase = ScriptableCharacter.scriptInit(scriptName);
+			trace([scriptName, info.info.name]);
+			characterInfos.set(info.info.name, info);
+			#if BACKWARD_COMPATIBILITY
+			var className = scriptName.split(".")[scriptName.split(".").length - 1];
+			characterInfos.set(className, info);
+			hideInfos.push(className);
+			#end
+		}
+	}
+
+	public static function listCharacters():Array<String>{
+		var result:Array<String> = [];
+		for (name => info in characterInfos){
+			if (!hideInfos.contains(name)){
+				result.push(name);
+			}
+		}
+
+		return result;
+	}
+
+	public static function getCharacterInfo(character:String):CharacterInfoBase
+	{
+		if (!characterInfos.exists(character)){
+			character = "bf";
+		}
+
+		return characterInfos.get(character);
+	}
 
 	public function new(x:Float, y:Float, ?_character:String = "Bf", ?_isPlayer:Bool = false, ?_isGirlfriend:Bool = false, ?_enableDebug:Bool = false){
 
@@ -101,9 +142,7 @@ class Character extends FlxSpriteGroup
 
 		antialiasing = true;
 
-		charClass = _character;
-
-		createCharacterFromInfo(charClass);
+		createCharacterFromInfo(_character);
 
 		if(!isFacingDefaultDirection && !debugMode){
 			setFlipX(true);
@@ -386,21 +425,19 @@ class Character extends FlxSpriteGroup
 
 	function createCharacterFromInfo(name:String):Void{
 
-		if(!ScriptableCharacter.listScriptClasses().contains(name)){ name = "Bf"; }
-		characterInfo = ScriptableCharacter.scriptInit(name);
+		characterInfo = getCharacterInfo(name);
 
 		characterInfo.characterReference = this;
 
 		//trace(characterInfo.info);
-		if(characterInfo.info.name != ""){ curCharacter = characterInfo.info.name; }
-		else{ curCharacter = name.toLowerCase(); }
+		curCharacter = characterInfo.info.name;
 			
 		iconName = characterInfo.info.iconName;
 		deathCharacter = characterInfo.info.deathCharacter;
 		characterColor = characterInfo.info.healthColor;
 		idleSequence = characterInfo.info.idleSequence;
-		focusOffset = characterInfo.info.focusOffset;
-		deathOffset = characterInfo.info.deathOffset;
+		focusOffset = characterInfo.info.focusOffset.clone();
+		deathOffset = characterInfo.info.deathOffset.clone();
 
 		if(isPlayer){ focusOffset.x *= -1; }
 
@@ -554,7 +591,7 @@ class Character extends FlxSpriteGroup
 		if(characterInfo.info.frameLoadType != atlas){ //Code for sheet characters
 			character.scale.set(_scaleX, _scaleY);
 			character.updateHitbox();
-			var offsetBase = new FlxPoint(offset.x, offset.y);
+			var offsetBase = FlxPoint.get(offset.x, offset.y);
 			for(name => pos in animOffsets){
 				addOffset(name, offsetBase.x + (originalAnimOffsets.get(name)[0] * _scaleX), offsetBase.y + (originalAnimOffsets.get(name)[1] * _scaleY));
 			}
@@ -562,7 +599,7 @@ class Character extends FlxSpriteGroup
 		else{ //Code for atlas characters
 			atlasCharacter.scale.set(_scaleX, _scaleY);
 			atlasCharacter.updateHitbox();
-			var offsetBase = new FlxPoint(offset.x, offset.y);
+			var offsetBase = FlxPoint.get(offset.x, offset.y);
 			for(name => pos in animOffsets){
 				addOffset(name, offsetBase.x + (originalAnimOffsets.get(name)[0] * _scaleX), offsetBase.y + (originalAnimOffsets.get(name)[1] * _scaleY));
 			}
@@ -1052,6 +1089,17 @@ class Character extends FlxSpriteGroup
 	
 	public function get_isFacingDefaultDirection():Bool{
 		return !(characterInfo.info.facesLeft && !isPlayer) && !(!characterInfo.info.facesLeft && isPlayer);
+	}
+
+	public override function destroy()
+	{
+		focusOffset.put();
+		deathOffset.put();
+		worldPopupOffset.put();
+
+		curOffset.put();
+
+		super.destroy();
 	}
 
 }

--- a/source/Character.hx
+++ b/source/Character.hx
@@ -27,6 +27,9 @@ class Character extends FlxSpriteGroup
 	public static final SHORT_SING_TOLERENCE:Float = 20;	//Millisecond tolerence for PREVENT_SHORT_SING detection.
 
 	public static var characterInfos:Map<String, CharacterInfoBase>;
+	#if BACKWARD_COMPATIBILITY
+	static var hideInfos:Array<String>;
+	#end
 
 	public var animOffsets:Map<String, Array<Dynamic>>;
 	private var originalAnimOffsets:Map<String, Array<Dynamic>>;
@@ -91,18 +94,26 @@ class Character extends FlxSpriteGroup
 
 	public static function initCharacters():Void{
 		characterInfos = new Map<String, CharacterInfoBase>();
+		hideInfos = [];
 		
 		for(scriptName in ScriptableCharacter.listScriptClasses()){
 			var info:CharacterInfoBase = ScriptableCharacter.scriptInit(scriptName);
+			trace([scriptName, info.info.name]);
+			characterInfos.set(info.info.name, info);
+			#if BACKWARD_COMPATIBILITY
 			var className = scriptName.split(".")[scriptName.split(".").length - 1];
 			characterInfos.set(className, info);
+			hideInfos.push(className);
+			#end
 		}
 	}
 
 	public static function listCharacters():Array<String>{
 		var result:Array<String> = [];
 		for (name => info in characterInfos){
-			result.push(name);
+			if (!hideInfos.contains(name)){
+				result.push(name);
+			}
 		}
 
 		return result;

--- a/source/Song.hx
+++ b/source/Song.hx
@@ -43,12 +43,6 @@ class Song
 	{
 		var swagShit:SwagSong = cast Json.parse(rawJson).song;
 
-		#if BACKWARD_COMPATIBILITY
-		swagShit.player1 = Character.getCharacterInfo(swagShit.player1).info.name;
-		swagShit.player2 = Character.getCharacterInfo(swagShit.player2).info.name;
-		swagShit.gf = Character.getCharacterInfo(swagShit.gf).info.name;
-		#end
-
 		return swagShit;
 	}
 	public static function parseEventJSON(rawJson:String):SongEvents

--- a/source/Song.hx
+++ b/source/Song.hx
@@ -46,6 +46,7 @@ class Song
 		#if BACKWARD_COMPATIBILITY
 		swagShit.player1 = Character.getCharacterInfo(swagShit.player1).info.name;
 		swagShit.player2 = Character.getCharacterInfo(swagShit.player2).info.name;
+		swagShit.gf = Character.getCharacterInfo(swagShit.gf).info.name;
 		#end
 
 		return swagShit;

--- a/source/Song.hx
+++ b/source/Song.hx
@@ -42,6 +42,12 @@ class Song
 	public static function parseJSONshit(rawJson:String):SwagSong
 	{
 		var swagShit:SwagSong = cast Json.parse(rawJson).song;
+
+		#if BACKWARD_COMPATIBILITY
+		swagShit.player1 = Character.getCharacterInfo(swagShit.player1).info.name;
+		swagShit.player2 = Character.getCharacterInfo(swagShit.player2).info.name;
+		#end
+
 		return swagShit;
 	}
 	public static function parseEventJSON(rawJson:String):SongEvents

--- a/source/editors/AnimationEditor.hx
+++ b/source/editors/AnimationEditor.hx
@@ -85,7 +85,7 @@ class AnimationEditor extends FlxState
 
 		dad = new Character(0, 0, daAnim, false, false, true);
 
-		charInfo = ScriptableCharacter.scriptInit(dad.charClass);
+		charInfo = Character.getCharacterInfo(dad.charClass);
 		if(charInfo.info.extraData != null){
 			for(type => data in charInfo.info.extraData){
 				switch(type){

--- a/source/editors/ChartingState.hx
+++ b/source/editors/ChartingState.hx
@@ -312,10 +312,10 @@ class ChartingState extends MusicBeatState
 				song: 'Test',
 				notes: [],
 				bpm: 150,
-				player1: 'bf',
-				player2: 'dad',
+				player1: 'Bf',
+				player2: 'Dad',
 				stage: 'Stage',
-				gf: 'gf',
+				gf: 'Gf',
 				speed: 1
 			};
 		}
@@ -440,10 +440,10 @@ class ChartingState extends MusicBeatState
 				song: song_name,
 				notes: [],
 				bpm: 120.0,
-				player1: 'bf',
-				player2: 'dad',
+				player1: 'Bf',
+				player2: 'Dad',
 				stage: 'Stage',
-				gf: 'gf',
+				gf: 'Gf',
 				speed: 1
 			};
 

--- a/source/editors/ChartingState.hx
+++ b/source/editors/ChartingState.hx
@@ -6,7 +6,6 @@ import stages.ScriptableStage;
 import note.NoteType;
 import characters.CharacterInfoBase;
 import modding.PolymodHandler;
-import characters.ScriptableCharacter;
 import events.Events;
 import sys.FileSystem;
 import ui.HealthIcon;
@@ -1533,8 +1532,8 @@ class ChartingState extends MusicBeatState
 			var leftChar:characters.CharacterInfoBase;
 			var rightChar:characters.CharacterInfoBase;
 
-			leftChar = ScriptableCharacter.scriptInit(player2DropDown.selectedLabel);
-			rightChar = ScriptableCharacter.scriptInit(player1DropDown.selectedLabel);
+			leftChar = Character.getCharacterInfo(player2DropDown.selectedLabel);
+			rightChar = Character.getCharacterInfo(player1DropDown.selectedLabel);
 
 			leftIcon.setIconCharacter(leftChar.info.iconName);
 			rightIcon.setIconCharacter(rightChar.info.iconName);
@@ -2173,8 +2172,8 @@ class ChartingState extends MusicBeatState
 		gfList = [];
 		stageList = [];
 
-		for(x in ScriptableCharacter.listScriptClasses()){
-			var getScriptInfo:CharacterInfoBase = ScriptableCharacter.scriptInit(x);
+		for(x in Character.listCharacters()){
+			var getScriptInfo:CharacterInfoBase = Character.getCharacterInfo(x);
 			if(getScriptInfo.includeInCharacterList){ charactersList.push(x); }
 			if(getScriptInfo.includeInGfList){ gfList.push(x); }
 		}

--- a/source/editors/ChartingState.hx
+++ b/source/editors/ChartingState.hx
@@ -314,7 +314,7 @@ class ChartingState extends MusicBeatState
 				bpm: 150,
 				player1: 'bf',
 				player2: 'dad',
-				stage: 'stage',
+				stage: 'Stage',
 				gf: 'gf',
 				speed: 1
 			};
@@ -440,10 +440,10 @@ class ChartingState extends MusicBeatState
 				song: song_name,
 				notes: [],
 				bpm: 120.0,
-				player1: 'Bf',
-				player2: 'Dad',
+				player1: 'bf',
+				player2: 'dad',
 				stage: 'Stage',
-				gf: 'Gf',
+				gf: 'gf',
 				speed: 1
 			};
 

--- a/source/modding/PolymodHandler.hx
+++ b/source/modding/PolymodHandler.hx
@@ -236,6 +236,7 @@ class PolymodHandler
 		Polymod.registerAllScriptClasses();
 		note.NoteType.initTypes();
 		events.Events.initEvents();
+		Character.initCharacters();
 	}
 
 	/*static function scriptableClassCheck():Void{


### PR DESCRIPTION
Polymod actually supports packages/namespaces. So, I reworked how we load CharacterInfoBase to make it work properly on custom packages and to utilize the unused "name" field.

The new method is lil similar to V-Slice. It constantly stores info using the character's class name field as the key, and retrieves and uses it when needed.

This is a breaking change because it replaces the reference when loading characters in chart editors and with character's name.
However, if the BACKWARD_COMPATIBILITY flag is present, the character names in the chart will be automatically updated when the song is loaded.