### PR TITLE
Charter & Events improvements

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -22,6 +22,7 @@
 		- Scary?
 	- Autosave.
 	- Sound effects? Maybe?
+	- Look into small memory leak when recycling notes/events?
 
 - Character Editor
 	- Kinda like a mix of the offset editor and the debug Character Compare thing.

--- a/art/futureDocs/Creating-a-Note-Type.md
+++ b/art/futureDocs/Creating-a-Note-Type.md
@@ -30,10 +30,10 @@ Writing a custom hit or miss function works the same as any other type of script
 
 ### Arguments
 
-Much like Events, you can pass arguments into a note type by adding them after the name of the note type, separated by semicolons. To parse out the arguments you can use `Events.getArgs(tag, defaultArguments)` to return an array of strings with the provided arguments and default arguments if they are omitted. Ex:
+Much like Events, you can pass arguments into a note type by adding them after the name of the note type, separated by semicolons. To parse out the arguments you can use `NoteType.getArgs(tag, defaultArguments)` to return an array of strings with the provided arguments and default arguments if they are omitted. If you do not provide `defaultArguments` it will try to get the default arguments based on the tag provided. Ex:
 
 ```haxe
-var args = Events.getArgs(note.type, ["", "", "true"]);
+var args = NoteType.getArgs(note.type, ["", "", "true"]);
 ```
 
 This will return `["", "", "true"]` if no arguments are provided and would return `["hey", "cheer", "false"]` if the provided tag was `playAnim;hey;cheer;false`. All arguments are strings, you can use `Events.parseInt()`, `Events.parseFloat()`, `Events.parseBool()`, `Events.parseTime()`, or `Events.parseEase()` to convert to other types.

--- a/assets/data/events/CameraEvents.hxc
+++ b/assets/data/events/CameraEvents.hxc
@@ -77,19 +77,19 @@ class CameraEvents extends Events
 	}
 
 	function camZoom(tag:String):Void{
-		var args = Events.getArgs(tag, Events.getDefaultArguments("camZoom"));
+		var args = Events.getArgs(tag);
 		var zoomLevel = Events.parseFloat(args[0]);
 		if(Events.parseBool(args[3])){ zoomLevel *= playstate.stage.startingZoom; }
 		playstate.camChangeZoom(zoomLevel, Events.parseTime(args[1]), Events.parseEase(args[2]), null);
 	}
 
 	function camBopFreq(tag:String):Void{
-		var args = Events.getArgs(tag, Events.getDefaultArguments("camBopFreq"));
+		var args = Events.getArgs(tag);
 		playstate.camBopFrequency = Events.parseInt(args[0]);
 	}
 	
 	function camBopIntensity(tag:String):Void{
-		var args = Events.getArgs(tag, Events.getDefaultArguments("camBopIntensity"));
+		var args = Events.getArgs(tag);
 		playstate.camBopIntensity = Events.parseFloat(args[0]);
 	}
 
@@ -106,67 +106,67 @@ class CameraEvents extends Events
 	}
 
 	function flash(tag:String):Void{
-		var args = Events.getArgs(tag, Events.getDefaultArguments("flash"));
+		var args = Events.getArgs(tag);
 		playstate.camGame.stopFX();
 		playstate.camGame.fade(ScriptingUtil.colorFromString(args[1]), Events.parseTime(args[0]), true);
 	}
 
 	function flashHud(tag:String):Void{
-		var args = Events.getArgs(tag, Events.getDefaultArguments("flashHud"));
+		var args = Events.getArgs(tag);
 		playstate.camHUD.stopFX();
 		playstate.camHUD.fade(ScriptingUtil.colorFromString(args[1]), Events.parseTime(args[0]), true);
 	}
 
 	function fadeOut(tag:String):Void{
-		var args = Events.getArgs(tag, Events.getDefaultArguments("fadeOut"));
+		var args = Events.getArgs(tag);
 		playstate.camGame.stopFX();
 		playstate.camGame.fade(ScriptingUtil.colorFromString(args[1]), Events.parseTime(args[0]));
 	}
 
 	function fadeOutHud(tag:String):Void{
-		var args = Events.getArgs(tag, Events.getDefaultArguments("fadeOutHud"));
+		var args = Events.getArgs(tag);
 		playstate.camHUD.stopFX();
 		playstate.camHUD.fade(ScriptingUtil.colorFromString(args[1]), Events.parseTime(args[0]));
 	}
 
 	function startCamShake(tag:String):Void{
-		var args = Events.getArgs(tag, Events.getDefaultArguments("startCamShake"));
+		var args = Events.getArgs(tag);
 		playstate.startCamShake(Events.parseFloat(args[0]), Events.parseTime(args[1]), Events.parseEase(args[2]));
 	}
 
 	function endCamShake(tag:String):Void{
-		var args = Events.getArgs(tag, Events.getDefaultArguments("endCamShake"));
+		var args = Events.getArgs(tag);
 		playstate.endCamShake(Events.parseTime(args[0]), Events.parseEase(args[1]));
 	}
 	
 	function camFocusBf(tag:String):Void{
-		var args = Events.getArgs(tag, Events.getDefaultArguments("camFocusBf"));
+		var args = Events.getArgs(tag);
 		playstate.camFocusBF(Events.parseFloat(args[0]), Events.parseFloat(args[1]), Events.parseTime(args[2]), Events.parseEase(args[3]));
 	}
 	
 	function camFocusDad(tag:String):Void{
-		var args = Events.getArgs(tag, Events.getDefaultArguments("camFocusDad"));
+		var args = Events.getArgs(tag);
 		playstate.camFocusOpponent(Events.parseFloat(args[0]), Events.parseFloat(args[1]), Events.parseTime(args[2]), Events.parseEase(args[3]));
 	}
 	
 	function camFocusGf(tag:String):Void{
-		var args = Events.getArgs(tag, Events.getDefaultArguments("camFocusGf"));
+		var args = Events.getArgs(tag);
 		playstate.camFocusGF(Events.parseFloat(args[0]), Events.parseFloat(args[1]), Events.parseTime(args[2]), Events.parseEase(args[3]));
 	}
 	
 	function camFocusCenter(tag:String):Void{
-		var args = Events.getArgs(tag, Events.getDefaultArguments("camFocusCenter"));
+		var args = Events.getArgs(tag);
 		var pos:FlxPoint = new FlxPoint(FlxMath.lerp(playstate.getOpponentFocusPosition().x, playstate.getBfFocusPostion().x, 0.5), FlxMath.lerp(playstate.getOpponentFocusPosition().y, playstate.getBfFocusPostion().y, 0.5));
 		playstate.camMove(pos.x + Events.parseFloat(args[0]), pos.y + Events.parseFloat(args[1]), Events.parseTime(args[2]), Events.parseEase(args[3]), "center");
 	}
 	
 	function camShake(tag:String):Void{
-		var args = Events.getArgs(tag, Events.getDefaultArguments("camShake"));
+		var args = Events.getArgs(tag);
 		playstate.camShake(Events.parseFloat(args[0]), Events.parseTime(args[1]), Events.parseTime(args[2]), Events.parseTime(args[3]), Events.parseEase(args[4]));
 	}
 	
 	function setDynamicCamAmount(tag:String):Void{
-		var args = Events.getArgs(tag, Events.getDefaultArguments("setDynamicCamAmount"));
+		var args = Events.getArgs(tag);
 		playstate.camOffsetAmount = Events.parseFloat(args[0]);
 	}
 

--- a/assets/data/events/CharacterAnimationEvents.hxc
+++ b/assets/data/events/CharacterAnimationEvents.hxc
@@ -101,7 +101,7 @@ class CharacterAnimationEvents extends Events
 	function changeCharacter(tag:String):Void{
 		var args = Events.getArgs(tag, ["bf", "Bf", "true"]);
 
-		if(!ScriptableCharacter.listScriptClasses().contains(args[1])){
+		if(!ScriptableCharacter.listScriptClasses().contains("characters." + args[1]) && !ScriptableCharacter.listScriptClasses().contains(args[1])){
 			trace("Invalid character: " + args[1]);
 			return;
 		}

--- a/assets/data/notetypes/AnimSetNotes.hxc
+++ b/assets/data/notetypes/AnimSetNotes.hxc
@@ -16,7 +16,7 @@ class AnimSetNotes extends NoteType
 	}
 
 	function animSetHit(note:Note, character:Character){
-		var args = Events.getArgs(note.type, NoteType.getDefaultArguments("animSet"));
+		var args = NoteType.getArgs(note.type);
 		var prevAnimSet = character.animSet;
 		character.animSet = args[0];
 		playstate.defaultNoteHit(note, character);
@@ -24,7 +24,7 @@ class AnimSetNotes extends NoteType
 	}
 
 	function animSetMiss(note:Note, character:Character){
-		var args = Events.getArgs(note.type, NoteType.getDefaultArguments("animSet"));
+		var args = NoteType.getArgs(note.type);
 		var prevAnimSet = character.animSet;
 		character.animSet = args[0];
 		playstate.defaultNoteMiss(note, character);

--- a/assets/data/notetypes/PlayAnimNotes.hxc
+++ b/assets/data/notetypes/PlayAnimNotes.hxc
@@ -40,7 +40,7 @@ class PlayAnimNotes extends NoteType
 
 
 	function playAnimHit(note:Note, character:Character){
-		var args = Events.getArgs(note.type, NoteType.getDefaultArguments("playAnim"));
+		var args = NoteType.getArgs(note.type);
 		if(character.canAutoAnim && shouldPlayAnimation(note, character)){
 			if(args[0] != ""){ character.singAnim(args[0], true); }
 			else{ playstate.defaultNoteHit(note, character); }
@@ -51,7 +51,7 @@ class PlayAnimNotes extends NoteType
 	}
 
 	function playAnimMiss(note:Note, character:Character){
-		var args = Events.getArgs(note.type, NoteType.getDefaultArguments("playAnim"));
+		var args = NoteType.getArgs(note.type);
 		if(character.canAutoAnim){
 			if(args[1] != ""){ character.singAnim(args[1], true); }
 			else{ playstate.defaultNoteMiss(note, character); }
@@ -72,7 +72,7 @@ class PlayAnimNotes extends NoteType
 
 
 	function heyHit(note:Note, character:Character){
-		var args = Events.getArgs(note.type, NoteType.getDefaultArguments("hey"));
+		var args = NoteType.getArgs(note.type);
 		if(character.canAutoAnim && shouldPlayAnimation(note, character)){
 			character.singAnim("hey", true);
 		}
@@ -82,7 +82,7 @@ class PlayAnimNotes extends NoteType
 	}
 
 	function cheerHit(note:Note, character:Character){
-		var args = Events.getArgs(note.type, NoteType.getDefaultArguments("week-2-cheer"));
+		var args = NoteType.getArgs(note.type);
 		if(character.canAutoAnim && shouldPlayAnimation(note, character)){
 			character.singAnim("cheer", true);
 		}
@@ -94,7 +94,7 @@ class PlayAnimNotes extends NoteType
 
 
 	function ughHit(note:Note, character:Character){
-		var args = Events.getArgs(note.type, NoteType.getDefaultArguments("ugh"));
+		var args = NoteType.getArgs(note.type);
 		if(character.canAutoAnim && shouldPlayAnimation(note, character)){
 			character.singAnim("ugh", true);
 		}
@@ -104,7 +104,7 @@ class PlayAnimNotes extends NoteType
 	}
 	
 	function arghHit(note:Note, character:Character){
-		var args = Events.getArgs(note.type, NoteType.getDefaultArguments("argh"));
+		var args = NoteType.getArgs(note.type);
 		if(character.canAutoAnim && shouldPlayAnimation(note, character)){
 			character.singAnim("argh", true);
 		}
@@ -116,7 +116,7 @@ class PlayAnimNotes extends NoteType
 
 
 	function shitHit(note:Note, character:Character){
-		var args = Events.getArgs(note.type, NoteType.getDefaultArguments("shit"));
+		var args = NoteType.getArgs(note.type);
 		if(character.canAutoAnim && shouldPlayAnimation(note, character)){
 			character.singAnim("shit", true);
 		}
@@ -126,7 +126,7 @@ class PlayAnimNotes extends NoteType
 	}
 
 	function shitCensorHit(note:Note, character:Character){
-		var args = Events.getArgs(note.type, NoteType.getDefaultArguments("shit-censor"));
+		var args = NoteType.getArgs(note.type);
 		if(character.canAutoAnim && shouldPlayAnimation(note, character)){
 			character.singAnim("shit-censor", true);
 		}
@@ -136,7 +136,7 @@ class PlayAnimNotes extends NoteType
 	}
 
 	function burpHit(note:Note, character:Character){
-		var args = Events.getArgs(note.type, NoteType.getDefaultArguments("burp"));
+		var args = NoteType.getArgs(note.type);
 		if(character.canAutoAnim && shouldPlayAnimation(note, character)){
 			character.singAnim("burp", true);
 		}
@@ -146,7 +146,7 @@ class PlayAnimNotes extends NoteType
 	}
 
 	function burpBigHit(note:Note, character:Character){
-		var args = Events.getArgs(note.type, NoteType.getDefaultArguments("burpBig"));
+		var args = NoteType.getArgs(note.type);
 		if(character.canAutoAnim && shouldPlayAnimation(note, character)){
 			character.singAnim("burpBig", true);
 		}

--- a/source/editors/chart/ChartingState.hx
+++ b/source/editors/chart/ChartingState.hx
@@ -639,7 +639,7 @@ class ChartingState extends MusicBeatState
 			}
 
 			if(gridCursorIndex == OPPONENT_GRID || gridCursorIndex == PLAYER_GRID){ //Placing notes.
-				if(FlxG.mouse.justPressed && !FlxG.keys.anyPressed([SHIFT]) && !panel.isAnythingFocused() && getNotesInRegion(getSongPositionFromY(gridCursor.y), gridCursorLane, gridCursorIndex == PLAYER_GRID, 2).length < 1){
+				if(FlxG.mouse.justPressed && !FlxG.keys.anyPressed([SHIFT]) && !panel.isAnythingFocused()){
 					var newNote = addNote(getSongPositionFromY(gridCursor.y), gridCursorLane, gridCursorIndex == PLAYER_GRID, noteTypeInput.value);
 					selectedNotes = [newNote];
 					placedNoteHold = true;
@@ -666,14 +666,14 @@ class ChartingState extends MusicBeatState
 				}
 			}
 			else if(gridCursorIndex == EVENT_GRID){ //Placing events.
-				if(FlxG.mouse.justPressed && !FlxG.keys.anyPressed([SHIFT]) && !panel.isAnythingFocused() && getEventsInRegion(getSongPositionFromY(gridCursor.y), gridCursorLane, 2).length < 1){
+				if(FlxG.mouse.justPressed && !FlxG.keys.anyPressed([SHIFT]) && !panel.isAnythingFocused()){
 					var newEvent = addEvent(getSongPositionFromY(gridCursor.y), gridCursorLane, eventTagInput.value);
 					selectedEvents = [newEvent];
 					createSnapshot(PLACE_EVENTS(1));
 					currentlySelectingEvents = true;
 				}
 				else if(FlxG.mouse.justPressedRight && !FlxG.keys.anyPressed([SHIFT])  && !panel.isAnythingFocused()){
-					var deleteCount:Int = removeEventsInProximity(getSongPositionFromY(FlxG.mouse.y - (GRID_SIZE/2)), gridCursorLane, ((getSongPositionFromY(FlxG.mouse.y + GRID_SIZE) - getSongPositionFromY(FlxG.mouse.y))/2)*0.999999);
+					var deleteCount:Int = removeEventsInProximity(getSongPositionFromY(FlxG.mouse.y - (GRID_SIZE/2)), gridCursorLane, null, ((getSongPositionFromY(FlxG.mouse.y + GRID_SIZE) - getSongPositionFromY(FlxG.mouse.y))/2)*0.999999);
 					selectedEvents = [];
 					if(deleteCount > 0){ createSnapshot(REMOVE_EVENTS(deleteCount)); }
 					currentlySelectingEvents = true;
@@ -941,7 +941,7 @@ class ChartingState extends MusicBeatState
 			else if(currentlySelectingEvents){
 				var deleteCount:Int = 0;
 				while(selectedEvents.length > 0){
-					deleteCount += removeEventsInProximity(selectedEvents[0].time, selectedEvents[0].lane, 1);
+					deleteCount += removeEventsInProximity(selectedEvents[0].time, selectedEvents[0].lane, null, 1);
 				}
 				selectedEvents = [];
 				if(deleteCount > 0){
@@ -994,7 +994,7 @@ class ChartingState extends MusicBeatState
 			else if(selectedEvents.length >= 1 && currentlySelectingEvents){
 				copyEvents();
 				while(selectedEvents.length > 0){
-					removeEventsInProximity(selectedEvents[0].time, selectedEvents[0].lane, 1);
+					removeEventsInProximity(selectedEvents[0].time, selectedEvents[0].lane, null, 1);
 				}
 				selectedEvents = [];
 				createAlert("Cut " + copiedEventData.length + " event" + (copiedEventData.length==1?".":"s."));
@@ -1087,7 +1087,7 @@ class ChartingState extends MusicBeatState
 	function addNote(strumTime:Float, direction:Int, player:Bool, tag:String = ""):ChartingNote{
 		removeNotesInProximity(strumTime, direction, player);
 
-		var newNote = notes.recycle(ChartingNote);
+		var newNote = notes.recycle(ChartingNote, null, true, true);
 		newNote.updateProperties(grids[player?1:0].grid.x + (GRID_SIZE * direction), getYFromSongPosition(strumTime), direction, strumTime, player, tag);
 		notes.members.sort(sortNotes);
 		
@@ -1155,9 +1155,9 @@ class ChartingState extends MusicBeatState
 	//Event stuff.
 
 	function addEvent(strumTime:Float, lane:Int, tag:String = ""):ChartingEvent{
-		//removeEventsInProximity(strumTime, lane);
+		removeEventsInProximity(strumTime, lane, tag);
 
-		var newEvent = events.recycle(ChartingEvent);
+		var newEvent = events.recycle(ChartingEvent, null, true, true);
 		newEvent.updateProperties(grids[2].grid.x + (GRID_SIZE * lane), getYFromSongPosition(strumTime), lane, strumTime, tag);
 		events.members.sort(sortEvents);
 		
@@ -1173,18 +1173,18 @@ class ChartingState extends MusicBeatState
 		return r;
 	}
 
-	function getEventsInRegion(strumTime:Float, lane:Null<Int>, region:Float = 5):Array<ChartingEvent>{
+	function getEventsInRegion(strumTime:Float, lane:Null<Int>, ?tag:String, region:Float = 5):Array<ChartingEvent>{
 		var r:Array<ChartingEvent> = [];
 		events.forEachAlive(function(event:ChartingEvent){
-			if(lane == null || event.lane == lane){
+			if((lane == null || event.lane == lane) && (tag == null || event.tag == tag)){
 				if(Utils.inRange(event.time, strumTime, region)){ r.push(event); }
 			}
 		});
 		return r;
 	}
 
-	function removeEventsInProximity(strumTime:Float, lane:Int, region:Float = 1):Int{
-		var removeList:Array<ChartingEvent> = getEventsInRegion(strumTime, lane, region);
+	function removeEventsInProximity(strumTime:Float, lane:Int, ?tag:String, region:Float = 1):Int{
+		var removeList:Array<ChartingEvent> = getEventsInRegion(strumTime, lane, tag, region);
 		for(event in removeList){
 			if(selectedEvents.contains(event)){ selectedEvents.remove(event); }
 			event.kill();
@@ -1194,7 +1194,7 @@ class ChartingState extends MusicBeatState
 
 	function getEventUnderCursor():ChartingEvent{
 		if(gridCursorIndex != EVENT_GRID){ return null; }
-		var eligibleEvents:Array<ChartingEvent> = getEventsInRegion(getSongPositionFromY(FlxG.mouse.y - (GRID_SIZE/2)), gridCursorLane, ((getSongPositionFromY(FlxG.mouse.y + GRID_SIZE) - getSongPositionFromY(FlxG.mouse.y))/2)*0.999999);
+		var eligibleEvents:Array<ChartingEvent> = getEventsInRegion(getSongPositionFromY(FlxG.mouse.y - (GRID_SIZE/2)), gridCursorLane, null, ((getSongPositionFromY(FlxG.mouse.y + GRID_SIZE) - getSongPositionFromY(FlxG.mouse.y))/2)*0.999999);
 		if(eligibleEvents.length == 0){ return null; }
 		eligibleEvents.sort(function(a:ChartingEvent, b:ChartingEvent):Int{
 			return Math.abs(a.time - getSongPositionFromY(FlxG.mouse.y)) < Math.abs(b.time - getSongPositionFromY(FlxG.mouse.y)) ? -1 : 1;

--- a/source/editors/chart/ChartingState.hx
+++ b/source/editors/chart/ChartingState.hx
@@ -59,6 +59,7 @@ typedef ChartSnapshot = {
 typedef ArgumentInput = {
 	var elements:Array<FlxSprite>;
 	var value:String;
+	var defaultValue:String;
 }
 
 //All the different actions that can be captured by the chart snapshot.
@@ -638,7 +639,7 @@ class ChartingState extends MusicBeatState
 			}
 
 			if(gridCursorIndex == OPPONENT_GRID || gridCursorIndex == PLAYER_GRID){ //Placing notes.
-				if(FlxG.mouse.justPressed && !FlxG.keys.anyPressed([SHIFT]) && !panel.isAnythingFocused()){
+				if(FlxG.mouse.justPressed && !FlxG.keys.anyPressed([SHIFT]) && !panel.isAnythingFocused() && getNotesInRegion(getSongPositionFromY(gridCursor.y), gridCursorLane, gridCursorIndex == 1, 2).length < 1){
 					var newNote = addNote(getSongPositionFromY(gridCursor.y), gridCursorLane, gridCursorIndex == 1, noteTypeInput.value);
 					selectedNotes = [newNote];
 					placedNoteHold = true;
@@ -665,7 +666,7 @@ class ChartingState extends MusicBeatState
 				}
 			}
 			else if(gridCursorIndex == EVENT_GRID){ //Placing events.
-				if(FlxG.mouse.justPressed && !FlxG.keys.anyPressed([SHIFT]) && !panel.isAnythingFocused()){
+				if(FlxG.mouse.justPressed && !FlxG.keys.anyPressed([SHIFT]) && !panel.isAnythingFocused() && getEventsInRegion(getSongPositionFromY(gridCursor.y), gridCursorLane, 2).length < 1){
 					var newEvent = addEvent(getSongPositionFromY(gridCursor.y), gridCursorLane, eventTagInput.value);
 					selectedEvents = [newEvent];
 					createSnapshot(PLACE_EVENTS(1));
@@ -1681,91 +1682,51 @@ class ChartingState extends MusicBeatState
 	}
 
 	function makeArgument(argData:EventArgument, y:Float, forNoteType:Bool):Void{
+		var arg:ArgumentInput = {elements: [], value: argData.value, defaultValue: argData.value};
+
+		function buildTag(){
+			if(!forNoteType) { buildEventTag(); } else { buildNoteTag(); }
+		}
+
 		switch(argData.type){
 			case bool:
-				var arg:ArgumentInput = {elements: [], value: argData.value};
-
 				var input:Toggle = new Toggle(PANEL_SPACING, y, Events.parseBool(argData.value), argData.name);
 				arg.elements.push(input);
 
 				input.onToggle.add(function(v:Bool){
 					arg.value = ""+v;
-					if(!forNoteType) { buildEventTag(); } else { buildNoteTag(); }
+					buildTag();
 				});
 
-				if(!forNoteType){
-					for(element in arg.elements){ panel.addToTab("Events", element); }
-					eventParams.push(arg);
-				}
-				else{
-					for(element in arg.elements){ panel.addToTab("Notes", element); }
-					noteParams.push(arg);
-				}
-
 			case int:
-				var arg:ArgumentInput = {elements: [], value: argData.value};
-
 				var input:Stepper = new Stepper(PANEL_SPACING, y, 192, Std.parseInt(argData.value), 1, null, null, true, argData.name);
 				input.isInt = true;
 				arg.elements.push(input);
 
 				input.onValueChanged.add(function(v:Float){
 					arg.value = ""+Std.int(v);
-					if(!forNoteType) { buildEventTag(); } else { buildNoteTag(); }
+					buildTag();
 				});
 
-				if(!forNoteType){
-					for(element in arg.elements){ panel.addToTab("Events", element); }
-					eventParams.push(arg);
-				}
-				else{
-					for(element in arg.elements){ panel.addToTab("Notes", element); }
-					noteParams.push(arg);
-				}
-
 			case float:
-				var arg:ArgumentInput = {elements: [], value: argData.value};
-
 				var input:Stepper = new Stepper(PANEL_SPACING, y, 192, Std.parseFloat(argData.value), 1, null, null, true, argData.name);
 				arg.elements.push(input);
 
 				input.onValueChanged.add(function(v:Float){
 					arg.value = ""+v;
-					if(!forNoteType) { buildEventTag(); } else { buildNoteTag(); }
+					buildTag();
 				});
 
-				if(!forNoteType){
-					for(element in arg.elements){ panel.addToTab("Events", element); }
-					eventParams.push(arg);
-				}
-				else{
-					for(element in arg.elements){ panel.addToTab("Notes", element); }
-					noteParams.push(arg);
-				}
-
 			case string:
-				var arg:ArgumentInput = {elements: [], value: argData.value};
-
 				var input:TextInput = new TextInput(PANEL_SPACING, y, 192, argData.value, argData.name);
 				arg.elements.push(input);
 
 				input.onValueChanged.add(function(v:String){
 					arg.value = v;
-					if(!forNoteType) { buildEventTag(); } else { buildNoteTag(); }
+					buildTag();
 				});
 
-				if(!forNoteType){
-					for(element in arg.elements){ panel.addToTab("Events", element); }
-					eventParams.push(arg);
-				}
-				else{
-					for(element in arg.elements){ panel.addToTab("Notes", element); }
-					noteParams.push(arg);
-				}
-
 			case ease:
-				var arg:ArgumentInput = {elements: [], value: argData.value};
-
 				final valueWithCaptital:String = argData.value.charAt(0).toUpperCase() + argData.value.substr(1, 99);
 				final initalEaseValue:String = argData.value.endsWith("In") ? valueWithCaptital.split("In")[0] : argData.value.endsWith("InOut") ? valueWithCaptital.split("InOut")[0] : argData.value.endsWith("Out") ? valueWithCaptital.split("Out")[0] : "Linear";
 				var easeDropdown:Dropdown = new Dropdown(PANEL_SPACING, y, 99, ["Linear", "Quad", "Cube", "Quart", "Quint", "SmoothStep", "SmooterStep", "Sine", "Bounce", "Circ", "Expo", "Back", "Elastic"], initalEaseValue);
@@ -1778,27 +1739,16 @@ class ChartingState extends MusicBeatState
 				easeDropdown.onSelect.add(function(v:String){
 					if(easeDropdown.value == "Linear"){ arg.value = "linear"; }
 					else{ arg.value = easeDropdown.value.charAt(0).toLowerCase() + easeDropdown.value.substr(1, 99) + directionDropdown.value; }
-					if(!forNoteType) { buildEventTag(); } else { buildNoteTag(); }
+					buildTag();
 				});
 
 				directionDropdown.onSelect.add(function(v:String){
 					if(easeDropdown.value == "Linear"){ arg.value = "linear"; }
 					else{ arg.value = easeDropdown.value.charAt(0).toLowerCase() + easeDropdown.value.substr(1, 99) + directionDropdown.value; }
-					if(!forNoteType) { buildEventTag(); } else { buildNoteTag(); }
+					buildTag();
 				});
 
-				if(!forNoteType){
-					for(element in arg.elements){ panel.addToTab("Events", element); }
-					eventParams.push(arg);
-				}
-				else{
-					for(element in arg.elements){ panel.addToTab("Notes", element); }
-					noteParams.push(arg);
-				}
-
 			case time:
-				var arg:ArgumentInput = {elements: [], value: argData.value};
-
 				var initalNumberValue:Float = argData.value.endsWith("b") ? Std.parseFloat(argData.value.split("b")[0]) : argData.value.endsWith("s") ? Std.parseFloat(argData.value.split("s")[0]) : Std.parseFloat(argData.value);
 				initalNumberValue = Math.isNaN(initalNumberValue) ? 0 : initalNumberValue;
 				var numberInput:Stepper = new Stepper(PANEL_SPACING, y, 110, initalNumberValue, 1, null, null, true);
@@ -1810,26 +1760,15 @@ class ChartingState extends MusicBeatState
 
 				numberInput.onValueChanged.add(function(v:Float){
 					arg.value = numberInput.value + (unitInput.value == "Beat" ? "b" : unitInput.value == "Step" ? "s" : "");
-					if(!forNoteType) { buildEventTag(); } else { buildNoteTag(); }
+					buildTag();
 				});
 
 				unitInput.onSelect.add(function(v:String){
 					arg.value = numberInput.value + (unitInput.value == "Beat" ? "b" : unitInput.value == "Step" ? "s" : "");
-					if(!forNoteType) { buildEventTag(); } else { buildNoteTag(); }
+					buildTag();
 				});
 
-				if(!forNoteType){
-					for(element in arg.elements){ panel.addToTab("Events", element); }
-					eventParams.push(arg);
-				}
-				else{
-					for(element in arg.elements){ panel.addToTab("Notes", element); }
-					noteParams.push(arg);
-				}
-
 			case character:
-				var arg:ArgumentInput = {elements: [], value: argData.value};
-
 				final initalValue:String = argData.value == "dad" ? "Opponent" : argData.value == "gf" ? "Speaker" : "Player";
 				var input:Dropdown = new Dropdown(PANEL_SPACING, y, 192, ["Player", "Opponent", "Speaker"], initalValue, argData.name);
 				arg.elements.push(input);
@@ -1843,21 +1782,10 @@ class ChartingState extends MusicBeatState
 						default:
 							arg.value = "bf";
 					}
-					if(!forNoteType) { buildEventTag(); } else { buildNoteTag(); }
+					buildTag();
 				});
-
-				if(!forNoteType){
-					for(element in arg.elements){ panel.addToTab("Events", element); }
-					eventParams.push(arg);
-				}
-				else{
-					for(element in arg.elements){ panel.addToTab("Notes", element); }
-					noteParams.push(arg);
-				}
 			
 			case color:
-				var arg:ArgumentInput = {elements: [], value: argData.value};
-
 				final initalValue:String = argData.value.startsWith("0x") ? argData.value.split("0x")[1] : argData.value;
 				var input:TextInput = new TextInput(PANEL_SPACING, y, 163, initalValue);
 				input.allowedCharacters = "0123456789ABCDEF";
@@ -1875,21 +1803,10 @@ class ChartingState extends MusicBeatState
 				input.onValueChanged.add(function(v:String){
 					arg.value = "0x"+v;
 					colorPreview.fillColor = FlxColor.fromString(arg.value);
-					if(!forNoteType) { buildEventTag(); } else { buildNoteTag(); }
+					buildTag();
 				});
 
-				if(!forNoteType){
-					for(element in arg.elements){ panel.addToTab("Events", element); }
-					eventParams.push(arg);
-				}
-				else{
-					for(element in arg.elements){ panel.addToTab("Notes", element); }
-					noteParams.push(arg);
-				}
-
 			case vocalTrack:
-				var arg:ArgumentInput = {elements: [], value: argData.value};
-
 				final initalValue:String = argData.value == "bf" ? "Player" : argData.value == "dad" ? "Opponent" : "Both";
 				var input:Dropdown = new Dropdown(PANEL_SPACING, y, 192, ["Player", "Opponent", "Both"], initalValue, argData.name);
 				arg.elements.push(input);
@@ -1903,33 +1820,38 @@ class ChartingState extends MusicBeatState
 						default:
 							arg.value = "all";
 					}
-					if(!forNoteType) { buildEventTag(); } else { buildNoteTag(); }
+					buildTag();
 				});
-
-				if(!forNoteType){
-					for(element in arg.elements){ panel.addToTab("Events", element); }
-					eventParams.push(arg);
-				}
-				else{
-					for(element in arg.elements){ panel.addToTab("Notes", element); }
-					noteParams.push(arg);
-				}
 
 			default:
 				trace("Type \"" + argData.type + "\" is not implemented!");
+		}
+		
+		if(!forNoteType){
+			for(element in arg.elements){ panel.addToTab("Events", element); }
+			eventParams.push(arg);
+		}
+		else{
+			for(element in arg.elements){ panel.addToTab("Notes", element); }
+			noteParams.push(arg);
 		}
 	}
 
 	function buildEventTag():Void{
 		var tag:String = eventPrefixDropdown.value;
-		for(arg in eventParams){ tag += ";" + arg.value; }
+		for(arg in eventParams){ tag += ";" + (arg.value != arg.defaultValue ? arg.value : ""); }
+		while(tag.endsWith(";")){
+			tag = tag.substr(0, tag.length - 1);
+		}
 		eventTagInput.value = tag;
 	}
 	
 	function buildNoteTag():Void{
 		var tag:String = notePrefixDropdown.value;
-		for(arg in noteParams){ tag += ";" + arg.value; }
+		for(arg in noteParams){ tag += ";" + (arg.value != arg.defaultValue ? arg.value : ""); }
+		while(tag.endsWith(";")){
+			tag = tag.substr(0, tag.length - 1);
+		}
 		noteTypeInput.value = tag;
 	}
-	
 }

--- a/source/editors/chart/ChartingState.hx
+++ b/source/editors/chart/ChartingState.hx
@@ -639,8 +639,8 @@ class ChartingState extends MusicBeatState
 			}
 
 			if(gridCursorIndex == OPPONENT_GRID || gridCursorIndex == PLAYER_GRID){ //Placing notes.
-				if(FlxG.mouse.justPressed && !FlxG.keys.anyPressed([SHIFT]) && !panel.isAnythingFocused() && getNotesInRegion(getSongPositionFromY(gridCursor.y), gridCursorLane, gridCursorIndex == 1, 2).length < 1){
-					var newNote = addNote(getSongPositionFromY(gridCursor.y), gridCursorLane, gridCursorIndex == 1, noteTypeInput.value);
+				if(FlxG.mouse.justPressed && !FlxG.keys.anyPressed([SHIFT]) && !panel.isAnythingFocused() && getNotesInRegion(getSongPositionFromY(gridCursor.y), gridCursorLane, gridCursorIndex == PLAYER_GRID, 2).length < 1){
+					var newNote = addNote(getSongPositionFromY(gridCursor.y), gridCursorLane, gridCursorIndex == PLAYER_GRID, noteTypeInput.value);
 					selectedNotes = [newNote];
 					placedNoteHold = true;
 					currentlySelectingEvents = false;

--- a/source/events/Events.hx
+++ b/source/events/Events.hx
@@ -132,24 +132,24 @@ class Events
 	* Splits the event tag at each `;` to get the event arguments.
 	*/
 	public static function getArgs(fullEventTag:String, ?defaultArgs:Array<String>):Array<String>{
-		var r:Array<String> = [];
+		var result:Array<String> = [];
+		var args:Array<String> = fullEventTag.split(";");
+		args.shift();
 
-		var args = fullEventTag.split(";");
-		for(i in 0...args.length){
-			if(i == 0) { continue; }
-			if(args[i].length == 0) { r.push(defaultArgs[i]); }
-			else{ r.push(args[i]); }
+		if(defaultArgs == null){
+			defaultArgs = getDefaultArguments(fullEventTag.split(";")[0]);
 		}
 
-		if(defaultArgs != null && defaultArgs.length > r.length){
-			for(i in 0...defaultArgs.length){
-				if(i >= r.length){
-					r.push(defaultArgs[i]);
-				}
+		if(defaultArgs.length > 0){
+			for (i in 0...defaultArgs.length){
+				result.push(args[i] != null && args[i].length > 0 ? args[i] : defaultArgs[i]);
 			}
-		}
 
-		return r;
+			return result;
+		}
+		else{
+			return args;
+		}
 	}
 
 	//For converting event properties to easing functions.

--- a/source/note/NoteType.hx
+++ b/source/note/NoteType.hx
@@ -126,6 +126,30 @@ class NoteType
 		};
 	}
 
+	/**
+	* Splits the event tag at each `;` to get the event arguments.
+	*/
+	public static function getArgs(fullEventTag:String, ?defaultArgs:Array<String>):Array<String>{
+		var result:Array<String> = [];
+		var args:Array<String> = fullEventTag.split(";");
+		args.shift();
+
+		if(defaultArgs == null){
+			defaultArgs = getDefaultArguments(fullEventTag.split(";")[0]);
+		}
+
+		if(defaultArgs.length > 0){
+			for (i in 0...defaultArgs.length){
+				result.push(args[i] != null && args[i].length > 0 ? args[i] : defaultArgs[i]);
+			}
+
+			return result;
+		}
+		else{
+			return args;
+		}
+	}
+
 	public static function getDefaultArguments(prefix:String):Array<String>{
 		var noteDefinition:NoteTypeDefinition = types.get(prefix);
 		if(noteDefinition == null){ return []; }


### PR DESCRIPTION
- Fixes several memory leaks in the chart editor.
- Rewrote Events.getArgs to ensure it always uses the correct default value.
- When generating tags in the chart editor, I made it so that if the value is the same as the default value, it will be left blank.
  - In addition, empty values ​​are trimmed if they appear consecutively at the end of a sequence.