### PR TITLE
Make the sustain a little longer (chart editor)

### DIFF
--- a/source/editors/chart/ChartingNote.hx
+++ b/source/editors/chart/ChartingNote.hx
@@ -123,12 +123,11 @@ class ChartingNote extends FlxTypedSpriteGroup<FlxSprite>
 	function updateSustainGraphics():Void{
 		if(sustainLength > 0){
 			sustainBody.visible = true;
-			sustainBody.setGraphicSize(SUSTAIN_GRAPHIC_WIDTH, (ChartingState.GRID_SIZE*(sustainLength-1))+(ChartingState.GRID_SIZE/2)+1);
+			sustainBody.setGraphicSize(SUSTAIN_GRAPHIC_WIDTH, (ChartingState.GRID_SIZE * sustainLength - 1));
 			sustainBody.updateHitbox();
 			
 			sustainEnd.visible = true;
-			sustainEnd.y = note.y + (ChartingState.GRID_SIZE*sustainLength);
-			sustainEnd.setGraphicSize(SUSTAIN_GRAPHIC_WIDTH, ChartingState.GRID_SIZE/2);
+			sustainEnd.y = note.y + sustainBody.height + sustainEnd.height;
 			sustainEnd.updateHitbox();
 		}
 		else{

--- a/source/editors/chart/ChartingNote.hx
+++ b/source/editors/chart/ChartingNote.hx
@@ -128,6 +128,7 @@ class ChartingNote extends FlxTypedSpriteGroup<FlxSprite>
 			
 			sustainEnd.visible = true;
 			sustainEnd.y = note.y + sustainBody.height + sustainEnd.height;
+			sustainEnd.setGraphicSize(SUSTAIN_GRAPHIC_WIDTH, ChartingState.GRID_SIZE/2);
 			sustainEnd.updateHitbox();
 		}
 		else{


### PR DESCRIPTION
I was trying out charting with the new editor, but it was a little difficult to tell how much I had lengthened the sustain note, so
<img width="216" height="569" alt="スクリーンショット 2026-05-27 14 06 07" src="https://github.com/user-attachments/assets/f738946e-e457-4ad5-82f9-e45e5e5b478f" />
